### PR TITLE
README: honest cost story, limitations section, voice pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@
 
 ![A pi session: the head picker adds a security head, then as the agent builds a Flask app the security head catches debug=True (a Werkzeug RCE) and an open-redirect risk and steers the fix into the conversation](docs/assets/demo.gif)
 
-hydra is a [pi](https://pi.dev/) extension that reviews your agent's work while the agent works. Each head is an observer with its own focus (quality, security, simplifier, API design, or anything you write) that sees exactly what the agent sees, judges every step, and answers with one of five decisions: stay quiet, print a note for you, queue feedback, steer the agent between turns, or interrupt and stop the run. Heads can act, too: by default a head may read, search, run, and write through the agent's own tools before it decides (a docs head keeps notes current while the agent codes). One body, many heads: the agent carries the context, and each additional head reads that context straight from the prompt cache. An observation costs about 1% of what the agent paid to build the context it reads; a session with an always-on head costs roughly 30% more ([What it costs](#what-it-costs)).
+hydra is a [pi](https://pi.dev/) extension that reviews your agent's work while the agent works. Each head watches with its own focus (quality, security, simplifier, API design, or anything you write): it sees exactly what the agent sees, judges every step, and answers with one of five decisions: stay quiet, print a note for you, queue feedback, steer the agent between turns, or interrupt and stop the run. Heads can act, too: by default a head may read, search, run, and write through the agent's own tools before it decides (a docs head keeps notes current while the agent codes). One body, many heads: the agent carries the context, and each additional head reads that context straight from the prompt cache. An observation costs about 1% of what the agent paid to build the context it reads; a session with an always-on head costs roughly 30% more ([What it costs](#what-it-costs)).
 
 ## Why
 
 Review usually happens after the work. The PR is finished, a reviewer (human or agent) loads the whole trajectory into fresh context at full price, and the findings arrive when the design is already set, so fixing them means rework. The same goes for evaluating agent behavior: replaying a finished trajectory into an eval agent costs full input price and happens too late to change anything.
 
-hydra inverts this. Observation happens during the run, at the exact moments the agent's own prompt cache commits, so a second perspective costs the observer prompt plus a cache read instead of a full context rebuild (numbers in [What it costs](#what-it-costs)). The decision usually lands while the agent's response is still streaming, early enough to steer the next step instead of rewriting a finished PR.
+hydra inverts this. Observation happens during the run, at the exact moments the agent's own prompt cache commits, so a second perspective costs the observation prompt plus a cache read instead of a full context rebuild (numbers in [What it costs](#what-it-costs)). The decision usually lands while the agent's response is still streaming, early enough to steer the next step instead of rewriting a finished PR.
 
 A bad assumption caught mid-implementation costs one correction message. Caught in review it costs a refactor.
 
 ## What it costs
 
-An observation costs the observer prompt (~220 tokens) plus a cache read at 10% of input price. On a 17K-token session that is about half a cent, or roughly 1% of what the driver paid to build the same context. Measured cache hit rates are 97%+ across real sessions; the 17K reference measurement hits 99%.
+An observation costs its prompt (~220 tokens) plus a cache read at 10% of input price. On a 17K-token session that is about half a cent, or roughly 1% of what the driver paid to build the same context. Measured cache hit rates are 97%+ across real sessions; the 17K reference measurement hits 99%.
 
 A session costs more than the per-observation number suggests. An always-on head observes at every cache commit, and a session has many of those. Measured across real sessions, one head adds roughly 30% to total session cost: a driver session that would cost $1.00 costs about $1.30.
 
@@ -88,7 +88,7 @@ Your heads live in `~/.pi/agent/hydra/`; a repo can ship its own in `.pi/hydra/`
 |---|---|
 | `/hydra-heads [set\|none]` | no argument opens the picker; an argument sets the active heads declaratively |
 | `/hydra-stats` | cache hit ratio, cost, recent decisions |
-| `/hydra-debug` | dump driver/observer payload pairs for diffing |
+| `/hydra-debug` | dump driver/observation payload pairs for diffing |
 
 The active head set persists per session and survives resume. For headless runs (`pi -p`), seed it with `--hydra-heads quality,security`. An explicit flag beats the saved session set; the saved set beats `autostart`.
 
@@ -112,7 +112,7 @@ The tool deliberately stops there. Everything the agent does to its heads is vis
 
 ## How it works
 
-hydra captures the agent's provider requests byte-for-byte and replays them, with one observer prompt appended, at the moments the agent's own prompt cache commits. Each observation is therefore a near-pure cache read, fresh through the latest tool results, and the cache stays warm for the agent. Every mechanism behind that sentence is measured rather than assumed; the measurements live in [`experiments/`](experiments/README.md) and the design in [`docs/architecture.md`](docs/architecture.md).
+hydra captures the agent's provider requests byte-for-byte and replays them, with one observation prompt appended, at the moments the agent's own prompt cache commits. Each observation is therefore a near-pure cache read, fresh through the latest tool results, and the cache stays warm for the agent. Every mechanism behind that sentence is measured rather than assumed; the measurements live in [`experiments/`](experiments/README.md) and the design in [`docs/architecture.md`](docs/architecture.md).
 
 ## Limitations
 
@@ -129,7 +129,7 @@ If that interests you, issues and PRs are welcome; see [CONTRIBUTING.md](CONTRIB
 
 ## History
 
-hydra began as **andon**, named for Toyota's emergency cord: any worker can stop the line when they spot a defect. The original was a bash and tmux contraption that reverse-engineered Claude Code's prompt pipeline to get cache parity, and its only job was interrupting the agent on urgent findings. The project has since outgrown interrupt-only (observers steer, queue, act, or stay quiet), and the pi extension replaced all of the reverse engineering with first-class hooks. The original lives in [`archive/`](archive/README.md), including the manufacturing-inspired manifesto that still explains the philosophy.
+hydra began as **andon**, named for Toyota's emergency cord: any worker can stop the line when they spot a defect. The original was a bash and tmux contraption that reverse-engineered Claude Code's prompt pipeline to get cache parity, and its only job was interrupting the agent on urgent findings. The project has since outgrown interrupt-only (heads steer, queue, act, or stay quiet), and the pi extension replaced all of the reverse engineering with first-class hooks. The original lives in [`archive/`](archive/README.md), including the manufacturing-inspired manifesto that still explains the philosophy.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ These are measurements, not estimates: the harness in [`experiments/`](experimen
 
 ## Compared to subagents
 
-pi ships four tools and no subagents; both arrive as extensions. They sit at opposite ends of two coupled choices. A head rides the driver's exact prompt cache, so it is locked to the driver's model and costs a cache read; a subagent ([pi-subagents](https://github.com/tintinweb/pi-subagents), the most capable pi subagent extension) rebuilds context from scratch, so it picks any model and pays full input price. And a head *watches in place*, replaying at the driver's commit points and able to act on what it sees live. A subagent is *spawned and returns*: it runs on its own clock and hands back a result the parent reads when it is done.
+pi's core ships four tools and no subagents; heads and subagents both arrive as extensions, and they sit at opposite ends of two coupled choices: where the reviewer's context comes from, and how its run relates to the driver's. On context, a head rides the driver's exact prompt cache, so it is locked to the driver's model and costs a cache read; a subagent ([pi-subagents](https://github.com/tintinweb/pi-subagents)) rebuilds context from scratch, so it picks any model and pays full input price. On the run, a head *watches in place*, replaying at the driver's commit points and able to act on what it sees live; a subagent is *spawned and returns*: it runs on its own clock and hands back a result the parent reads when it is done.
 
 | | subagents | hydra heads |
 |---|---|---|
-| Context | fresh, isolated by default; zero anchoring | the driver's payload byte-for-byte; maximal anchoring |
+| Context | fresh, isolated by default; zero anchoring to the driver's assumptions | the driver's payload byte-for-byte; fully anchored to the driver's assumptions |
 | Model | free: a stronger model for a real second opinion, or a cheap one for grunt work | locked to the driver's, always (the cache is model-specific) |
 | Cost | a full-price context rebuild per task | ~1% of build cost per observation; ~30% per session always-on |
 | Timing | on its own clock: Explore, Plan, a parallel worktree refactor, or a finished-artifact audit | live, at the driver's commit points, in time to steer the next step |

--- a/README.md
+++ b/README.md
@@ -6,15 +6,23 @@
 
 ![A pi session: the head picker adds a security head, then as the agent builds a Flask app the security head catches debug=True (a Werkzeug RCE) and an open-redirect risk and steers the fix into the conversation](docs/assets/demo.gif)
 
-hydra is a [pi](https://pi.dev/) extension that reviews your agent's work while the agent works. Each head is an observer with its own focus (quality, security, simplifier, API design, or anything you write) that sees exactly what the agent sees, judges every step, and answers with one of five decisions: stay quiet, print a note for you, queue feedback, steer the agent between turns, or interrupt and stop the run. Heads can act, too: by default a head may read, search, run, and write through the agent's own tools before it decides (a docs head keeps notes current while the agent codes). One body, many heads: the agent carries the context, and each additional head reads that context straight from the prompt cache for about 1% of what the agent paid to build it.
+hydra is a [pi](https://pi.dev/) extension that reviews your agent's work while the agent works. Each head is an observer with its own focus (quality, security, simplifier, API design, or anything you write) that sees exactly what the agent sees, judges every step, and answers with one of five decisions: stay quiet, print a note for you, queue feedback, steer the agent between turns, or interrupt and stop the run. Heads can act, too: by default a head may read, search, run, and write through the agent's own tools before it decides (a docs head keeps notes current while the agent codes). One body, many heads: the agent carries the context, and each additional head reads that context straight from the prompt cache. An observation costs about 1% of what the agent paid to build the context it reads; a session with an always-on head costs roughly 30% more ([What it costs](#what-it-costs)).
 
 ## Why
 
 Review usually happens after the work. The PR is finished, a reviewer (human or agent) loads the whole trajectory into fresh context at full price, and the findings arrive when the design is already set, so fixing them means rework. The same goes for evaluating agent behavior: replaying a finished trajectory into an eval agent costs full input price and happens too late to change anything.
 
-hydra inverts this. Observation happens during the run, at the exact moments the agent's own prompt cache commits, so a second perspective costs the observer prompt (~220 tokens) plus a cache read at 10% of input price. Concretely: an observation on a 17K-token session costs about half a cent and hits 99% cache; the decision usually lands while the agent's response is still streaming, early enough to steer the next step instead of rewriting a finished PR.
+hydra inverts this. Observation happens during the run, at the exact moments the agent's own prompt cache commits, so a second perspective costs the observer prompt plus a cache read instead of a full context rebuild (numbers in [What it costs](#what-it-costs)). The decision usually lands while the agent's response is still streaming, early enough to steer the next step instead of rewriting a finished PR.
 
 A bad assumption caught mid-implementation costs one correction message. Caught in review, it costs a refactor. Caught in production, an incident. The heads do not need to catch much to pay for themselves.
+
+## What it costs
+
+An observation costs the observer prompt (~220 tokens) plus a cache read at 10% of input price. On a 17K-token session that is about half a cent, or roughly 1% of what the driver paid to build the same context. Measured cache hit rates are 97%+ across real sessions; the 17K reference measurement hits 99%.
+
+A session costs more than the per-observation number suggests. An always-on head observes at every cache commit, and a session has many of those. Measured across real sessions, one head adds roughly 30% to total session cost: a driver session that would cost $1.00 costs about $1.30.
+
+These are measurements, not estimates: the harness in [`experiments/`](experiments/README.md) re-verifies the cache behavior against the live API, and `/hydra-stats` shows the same numbers live for your own sessions.
 
 ## Compared to subagents
 
@@ -24,7 +32,7 @@ pi ships four tools and no subagents; both arrive as extensions. They sit at opp
 |---|---|---|
 | Context | fresh, isolated by default; zero anchoring | the driver's payload byte-for-byte; maximal anchoring |
 | Model | free — a stronger model for a real second opinion, or a cheap one for grunt work | locked to the driver's, always (the cache is model-specific) |
-| Cost | a full-price context rebuild per task | ~1% of build cost — a cache read at 10% of input |
+| Cost | a full-price context rebuild per task | ~1% of build cost per observation; ~30% per session always-on |
 | Timing | on its own clock — Explore, Plan, a parallel worktree refactor, or a finished-artifact audit | live, at the driver's commit points — in time to steer the next step |
 | Direction | spawned downward; can be `steer`ed downward (parent → child) and returns a final message | watches the same run; can `steer` or pull the cord upward (head → agent) |
 | What crosses | passive data — inert until the parent reads and acts on it | an act — a `steer` or `interrupt` that fires whether the agent agrees or not |
@@ -105,6 +113,13 @@ The tool deliberately stops there. Everything the agent does to its heads is vis
 ## How it works
 
 hydra captures the agent's provider requests byte-for-byte and replays them, with one observer prompt appended, at the moments the agent's own prompt cache commits. Each observation is therefore a near-pure cache read, fresh through the latest tool results, and the cache stays warm for the agent. Every mechanism behind that sentence is measured rather than assumed; the measurements live in [`experiments/`](experiments/README.md) and the design in [`docs/architecture.md`](docs/architecture.md).
+
+## Limitations
+
+- Anthropic only, for now. The cache-parity replay is validated on the Anthropic Messages API; nothing else is verified.
+- A head runs the driver's model, always. The cache is model-specific, so a head cannot use a stronger or cheaper model than the driver's; that is what subagents are for.
+- A long generation streams to completion unjudged. Decisions form on committed request snapshots, so the cord is pulled between turns, never mid-stream ([Where this is going](#where-this-is-going)).
+- An always-on head adds roughly 30% to session cost ([What it costs](#what-it-costs)).
 
 ## Where this is going
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Review usually happens after the work. The PR is finished, a reviewer (human or 
 
 hydra inverts this. Observation happens during the run, at the exact moments the agent's own prompt cache commits, so a second perspective costs the observer prompt plus a cache read instead of a full context rebuild (numbers in [What it costs](#what-it-costs)). The decision usually lands while the agent's response is still streaming, early enough to steer the next step instead of rewriting a finished PR.
 
-A bad assumption caught mid-implementation costs one correction message. Caught in review, it costs a refactor. Caught in production, an incident. The heads do not need to catch much to pay for themselves.
+A bad assumption caught mid-implementation costs one correction message. Caught in review it costs a refactor.
 
 ## What it costs
 
@@ -26,18 +26,18 @@ These are measurements, not estimates: the harness in [`experiments/`](experimen
 
 ## Compared to subagents
 
-pi ships four tools and no subagents; both arrive as extensions. They sit at opposite ends of two coupled choices. A head rides the driver's exact prompt cache, so it is locked to the driver's model and costs a cache read; a subagent ([pi-subagents](https://github.com/tintinweb/pi-subagents), the most capable pi subagent extension) rebuilds context from scratch, so it picks any model and pays full input price. And a head *watches in place* — replaying at the driver's commit points, able to act on what it sees live — where a subagent is *spawned and returns*, on its own clock, handing back a result the parent reads when it is done.
+pi ships four tools and no subagents; both arrive as extensions. They sit at opposite ends of two coupled choices. A head rides the driver's exact prompt cache, so it is locked to the driver's model and costs a cache read; a subagent ([pi-subagents](https://github.com/tintinweb/pi-subagents), the most capable pi subagent extension) rebuilds context from scratch, so it picks any model and pays full input price. And a head *watches in place*, replaying at the driver's commit points and able to act on what it sees live. A subagent is *spawned and returns*: it runs on its own clock and hands back a result the parent reads when it is done.
 
 | | subagents | hydra heads |
 |---|---|---|
 | Context | fresh, isolated by default; zero anchoring | the driver's payload byte-for-byte; maximal anchoring |
-| Model | free — a stronger model for a real second opinion, or a cheap one for grunt work | locked to the driver's, always (the cache is model-specific) |
+| Model | free: a stronger model for a real second opinion, or a cheap one for grunt work | locked to the driver's, always (the cache is model-specific) |
 | Cost | a full-price context rebuild per task | ~1% of build cost per observation; ~30% per session always-on |
-| Timing | on its own clock — Explore, Plan, a parallel worktree refactor, or a finished-artifact audit | live, at the driver's commit points — in time to steer the next step |
+| Timing | on its own clock: Explore, Plan, a parallel worktree refactor, or a finished-artifact audit | live, at the driver's commit points, in time to steer the next step |
 | Direction | spawned downward; can be `steer`ed downward (parent → child) and returns a final message | watches the same run; can `steer` or pull the cord upward (head → agent) |
-| What crosses | passive data — inert until the parent reads and acts on it | an act — a `steer` or `interrupt` that fires whether the agent agrees or not |
+| What crosses | passive data, inert until the parent reads and acts on it | an act: a `steer` or `interrupt` that fires whether the agent agrees or not |
 
-Reach for a subagent when fresh eyes, a stronger model, or heavy isolated work is the point; reach for a head to catch the bad turn while it is still molten. The two stack around the driver: heads steer it from above, and it spawns subagents for the isolated work below.
+Reach for a subagent when fresh eyes, a stronger model, or heavy isolated work is the point; reach for a head to catch a bad turn during the run. The two stack around the driver: heads steer it from above, and it spawns subagents for the isolated work below.
 
 ## Quick start
 
@@ -106,7 +106,7 @@ Queue against steer is a timeliness choice; interrupt is for findings that canno
 
 ### The agent manages its own heads
 
-hydra registers a `hydra` tool the agent can call: `add` a head to the active set, `remove` one. Head files themselves the agent manages like any other file, with its ordinary tools: writing a head makes it available immediately (files are re-discovered on every tool call), and every change lands as a visible write in the session, auditable and diffable. A workflow can swap heads per phase the way an assembly line swaps tooling: design wants devil's-advocate thinking, execution wants quality and security, review wants simplifier.
+hydra registers a `hydra` tool the agent can call: `add` a head to the active set, `remove` one. Head files themselves the agent manages like any other file, with its ordinary tools: writing a head makes it available immediately (files are re-discovered on every tool call), and every change lands as a visible write in the session, auditable and diffable. A workflow can swap heads per phase: design wants devil's-advocate thinking, execution wants quality and security, review wants simplifier.
 
 The tool deliberately stops there. Everything the agent does to its heads is visible and reversible: set changes are announced, head files are plain markdown you can read and `git diff`. Turning hydra off entirely is pi's extension enable/disable, which stays yours.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,21 @@ hydra inverts this. Observation happens during the run, at the exact moments the
 
 A bad assumption caught mid-implementation costs one correction message. Caught in review, it costs a refactor. Caught in production, an incident. The heads do not need to catch much to pay for themselves.
 
+## Compared to subagents
+
+pi ships four tools and no subagents; both arrive as extensions. They sit at opposite ends of two coupled choices. A head rides the driver's exact prompt cache, so it is locked to the driver's model and costs a cache read; a subagent ([pi-subagents](https://github.com/tintinweb/pi-subagents), the most capable pi subagent extension) rebuilds context from scratch, so it picks any model and pays full input price. And a head *watches in place* — replaying at the driver's commit points, able to act on what it sees live — where a subagent is *spawned and returns*, on its own clock, handing back a result the parent reads when it is done.
+
+| | subagents | hydra heads |
+|---|---|---|
+| Context | fresh, isolated by default; zero anchoring | the driver's payload byte-for-byte; maximal anchoring |
+| Model | free — a stronger model for a real second opinion, or a cheap one for grunt work | locked to the driver's, always (the cache is model-specific) |
+| Cost | a full-price context rebuild per task | ~1% of build cost — a cache read at 10% of input |
+| Timing | on its own clock — Explore, Plan, a parallel worktree refactor, or a finished-artifact audit | live, at the driver's commit points — in time to steer the next step |
+| Direction | spawned downward; can be `steer`ed downward (parent → child) and returns a final message | watches the same run; can `steer` or pull the cord upward (head → agent) |
+| What crosses | passive data — inert until the parent reads and acts on it | an act — a `steer` or `interrupt` that fires whether the agent agrees or not |
+
+Reach for a subagent when fresh eyes, a stronger model, or heavy isolated work is the point; reach for a head to catch the bad turn while it is still molten. The two stack around the driver: heads steer it from above, and it spawns subagents for the isolated work below.
+
 ## Quick start
 
 You need [pi](https://pi.dev/) with an Anthropic model (hydra's cache-parity replay is validated on the Anthropic Messages API).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,11 +4,11 @@ How hydra observes a pi session at prompt-cache prices. For the what and why, st
 
 ## Commit-point observation
 
-hydra replays the driver's exact provider payload with one observer prompt appended (the driver: pi's main agent, the one you talk to; the observers are the heads watching it). Because the prefix is byte-identical, every observation is a prompt-cache read of the entry the driver itself just wrote. Observations fire at the driver's own cache commit points, on two triggers:
+hydra replays the driver's exact provider payload with one observation prompt appended (the driver: pi's main agent, the one you talk to; the heads watch it). Because the prefix is byte-identical, every observation is a prompt-cache read of the entry the driver itself just wrote. Observations fire at the driver's own cache commit points, on two triggers:
 
-**Piggyback (mid-run).** When a driver response begins streaming (`message_start`, the moment Anthropic's cache entry becomes readable; commit+0 free rides verified), hydra replays that request's captured payload plus an observer prompt. The driver just paid the cache write, so the observation is a pure cache read, includes the latest assistant message and tool results, and its decision typically lands while the driver's response is still streaming. The run's first response is skipped: the previous run-end observation already reviewed everything before it.
+**Piggyback (mid-run).** When a driver response begins streaming (`message_start`, the moment Anthropic's cache entry becomes readable; commit+0 free rides verified), hydra replays that request's captured payload plus an observation prompt. The driver just paid the cache write, so the observation is a pure cache read, includes the latest assistant message and tool results, and its decision typically lands while the driver's response is still streaming. The run's first response is skipped: the previous run-end observation already reviewed everything before it.
 
-**Run-end (agent_end).** When the driver hands control back to the user, no next request will carry the final assistant message M into the cache, so the observer appends M itself. It hands M to its `runAgentLoop` call, and pi-ai's own provider code serializes it: thinking blocks, signatures, surrogate sanitization, parity by construction rather than by mirroring. The `onPayload` hook then splices that output onto the captured prefix and moves the driver's message-level cache marker (TTL included) onto M's last markable block (text or tool_use), staying inside the 4-breakpoint budget. The observer pays M's write once (1.25×) and pre-warms the driver's next turn, which reads M at 0.1×: a ~5:1 bet that lands because human latency far exceeds observer TTFT.
+**Run-end (agent_end).** When the driver hands control back to the user, no next request will carry the final assistant message M into the cache, so the observation appends M itself. It hands M to its `runAgentLoop` call, and pi-ai's own provider code serializes it: thinking blocks, signatures, surrogate sanitization, parity by construction rather than by mirroring. The `onPayload` hook then splices that output onto the captured prefix and moves the driver's message-level cache marker (TTL included) onto M's last markable block (text or tool_use), staying inside the 4-breakpoint budget. The observation pays M's write once (1.25×) and pre-warms the driver's next turn, which reads M at 0.1×: a ~5:1 bet that lands because human latency far exceeds observation TTFT.
 
 ```
 mid-run:  request N+1 dispatched ─► payload captured
@@ -26,7 +26,7 @@ steer     → pi.sendUserMessage({ deliverAs: "steer" })
 interrupt → ctx.abort() + pi.sendUserMessage({ deliverAs: "followUp" })
 ```
 
-Same model, same system prompt, same tools, same thinking config; the only difference is one extra user message at the end. Cache hit ratio is determined by the size of the observer prompt (~220 tokens) relative to the driver context.
+Same model, same system prompt, same tools, same thinking config; the only difference is one extra user message at the end. Cache hit ratio is determined by the size of the observation prompt (~220 tokens) relative to the driver context.
 
 Observations run through a conflating single-slot scheduler, per head: every head has at most one observation in flight and one waiting slot that a newer snapshot overwrites, and an in-flight observation always runs to completion. Staleness is bounded to one cycle because the slot always holds the newest snapshot. The granularity is per head rather than one global batch so an acting head's minutes-long tool loop cannot starve the judging heads, and a head that is busy through a commit point still reviews the newest snapshot the moment it frees up.
 
@@ -36,7 +36,7 @@ A head is fully defined by one markdown file ([`heads.md`](heads.md) has the for
 
 ## Cache hit ratio (the load-bearing metric)
 
-| Driver context | Observer prompt | Theoretical hit |
+| Driver context | Observation prompt | Theoretical hit |
 |---:|---:|---:|
 | 4K | 220 | 94.8% |
 | 10K | 220 | 97.8% |
@@ -64,11 +64,11 @@ The measurement above is from the earlier turn_end-era architecture. The current
 Two measured facts fix the timing (the measurements live in [`../experiments/`](../experiments/README.md)):
 
 - A cache entry becomes readable the moment the writing request's response begins (`message_start` ≈ TTFT). Post-commit propagation is indistinguishable from zero; commit+0 free rides verified on haiku and fable, with and without thinking.
-- A response is never cached by the request that produced it. An observer that does not append M itself reviews a context that is exactly one assistant message stale.
+- A response is never cached by the request that produced it. An observation that does not append M itself sees a context that is exactly one assistant message stale.
 
 Hence the two triggers: mid-run observations fire at the driver's own commit (`message_start` of its response), where everything is already cached and fresh through the tool results; run-end observations append M and pay its write once, pre-warming the driver's next turn. No delays, no propagation heuristics. The driver's cadence provides the cache-coherent observation points.
 
-M's serialization is parity by construction: the observer hands M to its `runAgentLoop` call, and the `onPayload` hook splices pi-ai's own provider output onto the captured prefix. The fork's bytes match the driver's next request through the exact code path that will produce it, including surrogate sanitization and the dropping of aborted or errored messages. There is no hand-maintained mirror to drift when pi-ai changes.
+M's serialization is parity by construction: the observation hands M to its `runAgentLoop` call, and the `onPayload` hook splices pi-ai's own provider output onto the captured prefix. The fork's bytes match the driver's next request through the exact code path that will produce it, including surrogate sanitization and the dropping of aborted or errored messages. There is no hand-maintained mirror to drift when pi-ai changes.
 
 Selecting M is identity matching, not clock comparison. pi constructs the response message about a millisecond before `before_provider_request` fires, so any wall-clock comparison against the capture time is a same-millisecond coin flip that silently drops M on the losing side (measured: -1ms, 0ms, -1ms across three runs). hydra records the response's own timestamp at its `message_start` and attaches M only on an exact match; runs whose final request errored or aborted have no response to match and correctly attach nothing.
 
@@ -86,7 +86,7 @@ By default a head may run tool calls before its decision; a head file's `tools:`
 
 **The loop is pi's own, and it is the only path.** Every observation runs `runAgentLoop` from pi-agent-core (a first-class extension import; the loader aliases it in both bundle modes) rather than a hand-rolled imitation: argument validation, "tool not found" error results, parallel-vs-sequential execution policy, and abort discipline stay pi's code and evolve with it. A judge-only head is not a separate code path, just the zero-tool case: it answers in one turn and the loop exits, one provider call exactly like a bare `complete()`. The same reuse philosophy as M's serialization: run the real thing instead of mirroring it.
 
-**Every loop call replays the captured prefix.** The loop's own built context is discarded by the `onPayload` merge, so iteration N's request is the byte-true driver prefix plus the observer's tail (`[M?, prompt, turn 1, results 1, ..., turn N-1]`). The driver prefix stays a pure cache read on every iteration; measured live, read stayed at the full committed prefix while only tail content was written.
+**Every loop call replays the captured prefix.** The loop's own built context is discarded by the `onPayload` merge, so iteration N's request is the byte-true driver prefix plus the observation tail (`[M?, prompt, turn 1, results 1, ..., turn N-1]`). The driver prefix stays a pure cache read on every iteration; measured live, read stayed at the full committed prefix while only tail content was written.
 
 **Tool parity comes from the replay itself.** The model can only call tools in the replayed payload's tools array, which is the driver's active set by construction. hydra executes the seven standard tools (constructed from pi's exported factories at the driver's cwd) plus its own `hydra` tool, filtered down to the head file's `tools:` list when one is given; a call outside the list, or to anything hydra cannot execute (another extension's tool, MCP), gets pi's standard error result and the head proceeds to its decision. write/edit serialize same-file mutations through pi's process-wide queue, shared with the driver because the loader aliases pi-coding-agent to its bundled instance.
 
@@ -94,7 +94,7 @@ By default a head may run tool calls before its decision; a head file's `tools:`
 
 **Loops are guarded, not budgeted.** There is no cost ceiling; the only bound is a correctness guard: a loop that has not produced a decision after 25 model turns is wound down as a `noop` with a warning, and removing the head from the active set mid-loop winds it down at the next turn boundary. Stats record one `hydra-call` per observation with usage summed across iterations; the hit ratio is taken from the first call alone, since it is the replay-parity signal and later iterations legitimately pay the tail as fresh input.
 
-**File writes are announced.** Every successful write/edit queues a one-line `hydra-feedback` note (`[docs] wrote docs/notes.md`): provenance, not a finding, so the driver is never surprised by files changing under it. Writes inside the observer's bash commands are invisible to this; the authoring guidance in [`heads.md`](heads.md) says to keep bash read-only mid-run.
+**File writes are announced.** Every successful write/edit queues a one-line `hydra-feedback` note (`[docs] wrote docs/notes.md`): provenance, not a finding, so the driver is never surprised by files changing under it. Writes inside the head's bash commands are invisible to this; the authoring guidance in [`heads.md`](heads.md) says to keep bash read-only mid-run.
 
 **Decisions from stale snapshots cannot pull the cord.** An acting head can finish its loop minutes after its snapshot was captured. If the driver has moved on to a newer request, an `interrupt` decision demotes to `steer`: a wrong demotion costs one turn of latency, a wrong abort destroys in-flight work.
 
@@ -102,13 +102,13 @@ By default a head may run tool calls before its decision; a head file's `tools:`
 
 **Anthropic-only for v0.1.** The capture/replay pattern requires the provider to support prompt caching with explicit `cache_control` markers, validated so far only on Anthropic's Messages API. OpenAI, Google etc. would either need their own cache markers or fall through to no-cache (still works, but expensive). Detected at runtime: hydra skips observation, with a one-time warning, when the driver is on a non-Anthropic provider.
 
-**Acting heads cannot be hard-aborted mid-tool.** The lifecycle abort signal reaches the loop at turn boundaries and tool executions receive it, but a long-running bash command started by an observer runs to completion on shutdown grace expiry. Known limitation, accepted for now.
+**Acting heads cannot be hard-aborted mid-tool.** The lifecycle abort signal reaches the loop at turn boundaries and tool executions receive it, but a long-running bash command started by a head runs to completion on shutdown grace expiry. Known limitation, accepted for now.
 
-**Cold-start observation is below 97%.** The first observation in a fresh session has a small driver context that the observer prompt nearly equals in size. Accepted; the metric converges fast once any history exists.
+**Cold-start observation is below 97%.** The first observation in a fresh session has a small driver context that the observation prompt nearly equals in size. Accepted; the metric converges fast once any history exists.
 
 **Headless (`pi -p`) may truncate the run-end observation.** The process exits shortly after `agent_end`; `session_shutdown` awaits the in-flight observation up to 5s, which slow models (fable/xhigh: 10s+) can exceed. Raise via `HYDRA_SHUTDOWN_GRACE_MS` for headless use (`0` means exit without waiting). Interactive mode is unaffected; the observation completes while you read the response.
 
-**Multi-head fan-out is latency-first.** The active head set fans out one observation per head, in parallel, per trigger. Mid-run this is free beyond the prompts, since every head is a pure cache read of the same committed prefix. At run-end the markered forks race and each pays M's write (~$0.01–0.02 per head on fable, measured); the experiments README documents a message_start-coordination pattern that would let followers free-ride on the first fork's write, deliberately not implemented because the contended amount stays a single-digit percent of observer spend and feedback latency is the product metric.
+**Multi-head fan-out is latency-first.** The active head set fans out one observation per head, in parallel, per trigger. Mid-run this is free beyond the prompts, since every head is a pure cache read of the same committed prefix. At run-end the markered forks race and each pays M's write (~$0.01–0.02 per head on fable, measured); the experiments README documents a message_start-coordination pattern that would let followers free-ride on the first fork's write, deliberately not implemented because the contended amount stays a single-digit percent of observation spend and feedback latency is the product metric.
 
 **Decisions judge committed snapshots, not in-flight output.** Interrupt does cancel: an `interrupt` decision calls `ctx.abort()` on the in-flight run and the finding opens the next one, matching the archived bash version's Escape-then-inject behavior. Steer is the softer rung: the message waits for the current turn's tool calls to finish, then lands between turns of the same run, and the piggyback timing means decisions often arrive while a response is still streaming, in time for the very next turn boundary. What remains future work is judging *partial* output: every decision is formed from a committed request snapshot, so a single long-running LLM call is never evaluated mid-generation. That would require reasoning over `message_update` deltas, with no cache parity since the content is mid-flight.
 
@@ -135,15 +135,15 @@ Smoke-test the delivery pipeline with the hidden diagnostic heads: `/hydra-heads
 /hydra-debug        # toggles off
 # inspect (filenames carry timestamp, head, and sequence):
 ls /tmp/hydra-debug-*/
-# A piggyback pair differs only by the appended observer prompt; dropping it
-# from the observer payload must reproduce the driver payload byte-for-byte:
+# A piggyback pair differs only by the appended observation prompt; dropping it
+# from the observation payload must reproduce the driver payload byte-for-byte:
 jq -S '.' <driver.json> > /tmp/drv.json
-jq -S 'del(.messages[-1])' <observer.json> > /tmp/obs.json
+jq -S 'del(.messages[-1])' <observation.json> > /tmp/obs.json
 diff /tmp/drv.json /tmp/obs.json   # expected: empty
 # A run-end fork additionally appends M and moves the message-level cache
 # marker onto it, so drop both tail messages and the markers before diffing:
 jq -S 'walk(if type == "object" then del(.cache_control) else . end)' <driver.json> > /tmp/drv.json
-jq -S 'del(.messages[-2:]) | walk(if type == "object" then del(.cache_control) else . end)' <observer.json> > /tmp/obs.json
+jq -S 'del(.messages[-2:]) | walk(if type == "object" then del(.cache_control) else . end)' <observation.json> > /tmp/obs.json
 diff /tmp/drv.json /tmp/obs.json   # expected: empty
 ```
 
@@ -153,10 +153,10 @@ hydra began as [andon](../archive/README.md), a bash and tmux contraption around
 
 | | andon (bash, archived) | pi-hydra |
 |---|---|---|
-| Cache parity | 8 normalization rules in `andon-cache-fix.mjs` patching `globalThis.fetch` | byte-true replay via `before_provider_request` capture + `onPayload` override on the observer's own provider call |
+| Cache parity | 8 normalization rules in `andon-cache-fix.mjs` patching `globalThis.fetch` | byte-true replay via `before_provider_request` capture + `onPayload` override on the observation's own provider call |
 | Driver inheritance | `claude --resume <id> --fork-session --print` subprocess | `runAgentLoop` call from inside the driver process |
-| Observer state | JSON file in `~/.local/state/andon-observer/` | session custom entries via `pi.appendEntry("hydra-call", ...)` |
+| Observation state | JSON file in `~/.local/state/andon-observer/` | session custom entries via `pi.appendEntry("hydra-call", ...)` |
 | Delivery | `tmux send-keys` | `pi.sendMessage` / `pi.sendUserMessage` |
 | Polling | JSONL mtime watch loop | driver commit events (`message_start`) + `agent_end` |
-| Self-feedback prevention | `recent_decisions` injected into prompt (caused hallucination loops) | delivered-set dedup; queued feedback becomes part of the replayed context by design, since the observer sees exactly what the driver sees |
+| Self-feedback prevention | `recent_decisions` injected into prompt (caused hallucination loops) | delivered-set dedup; queued feedback becomes part of the replayed context by design, since the head sees exactly what the driver sees |
 | Status display | none / external log | TUI footer with live hit ratio + cost |

--- a/docs/heads.md
+++ b/docs/heads.md
@@ -1,6 +1,6 @@
 # Heads
 
-A head is an observer with its own perspective: it sees exactly what the agent sees, judges every step, and answers with one of five decisions (noop, print, queue, steer, interrupt). A head is fully defined by one markdown file. The file carries the head's identity, its capabilities, and its instruction; there is nothing else to configure.
+A head watches with its own perspective: it sees exactly what the agent sees, judges every step, and answers with one of five decisions (noop, print, queue, steer, interrupt). A head is fully defined by one markdown file. The file carries the head's identity, its capabilities, and its instruction; there is nothing else to configure.
 
 ## Head files
 
@@ -69,7 +69,7 @@ Authoring guidance for heads that act:
 
 1. **Direct the tool use explicitly.** The wrapper permits tools; the head's instruction says when and on what. A head that only judges should carry `tools: []` and keep the snappy single-call path.
 2. **Say what the decision should usually be.** Acting heads typically end `noop` (the work product is their side effect), `print` (a note for you), or `steer` (a research head delivering a finding).
-3. **Avoid state-mutating bash mid-run.** The observer works while the agent works. File writes through write/edit serialize against the agent's own writes and are announced in the session; bash output does neither, so keep bash to reads (builds, greps, lookups) unless you accept the race.
+3. **Avoid state-mutating bash mid-run.** The head works while the agent works. File writes through write/edit serialize against the agent's own writes and are announced in the session; bash output does neither, so keep bash to reads (builds, greps, lookups) unless you accept the race.
 4. **Loops are bounded, not budgeted.** A head that has not produced a decision after 25 model turns is wound down with a warning. There is no cost ceiling; the head's instruction is the throttle.
 
 ## Decisions: when findings land

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -12,7 +12,7 @@ and the economics of replacing it with fork-from-n. Run June 2026 on
 | `cache-latest-message.mjs` | Is the driver's latest assistant message M cached after the driver's own turn? What do n-1 vs n forks cost, serial and parallel? |
 | `cache-timing.mjs` | When does a cache write become readable: at writer ingestion, mid-processing, or response completion? |
 | `cache-stagger.mjs` | 4 forks, one writer at t=0, three delayed by `--stagger-ms`: do the delayed ones free-ride? `--m-words` scales M, `--thinking` enables adaptive thinking, `--stagger-from commit` anchors the stagger on the writer's `message_start` |
-| `cache-thinking-walkback.mjs` | Does a driver-shaped next request (marker only on its own new user message, none on M) find the observer's prefix+M entry via breakpoint walk-back when M carries thinking blocks? |
+| `cache-thinking-walkback.mjs` | Does a driver-shaped next request (marker only on its own new user message, none on M) find the observation's prefix+M entry via breakpoint walk-back when M carries thinking blocks? |
 | `cache-automatic.mjs` | Does automatic caching (top-level `cache_control`) cache the generated response? (No.) |
 
 `lib.mjs` holds the shared harness: OAuth, padding, the Messages call, and
@@ -46,7 +46,7 @@ request that generated it.
 
 ### 2. n-1 forks are pure cache reads, even ×3 parallel (H2 ✅)
 
-write=0, read=full prefix, input ≈ observer prompt (~119 tok) for all three
+write=0, read=full prefix, input ≈ observation prompt (~119 tok) for all three
 simultaneous n-1 forks. This was the original hydra behavior: cheap, but it
 judges a stale snapshot (the cause of the stale-review bug).
 
@@ -55,7 +55,7 @@ judges a stale snapshot (the cause of the stale-review bug).
 First fork pays cache_creation ≈ M (1.25×); a later serial fork reads it
 (0.1×). Marker placement doesn't matter for lookup: a driver-shaped request
 (marker only on its own new user message) finds the prefix+M entry via
-breakpoint walk-back. An observer fork-from-n with a marker on M therefore
+breakpoint walk-back. An observation fork-from-n with a marker on M therefore
 pre-warms the driver's next turn.
 
 ### 4. Write commit is at TTFT ("once the response begins"), not completion
@@ -180,11 +180,11 @@ all visibility delay into TTFT + transport:
 
 Pricing (per MTok, pi registry): input $10, output $50, cacheRead $1,
 cacheWrite $12.50. Base is 3.33× Sonnet; the multipliers are identical
-(1.25× / 0.1×). For N=4 observers and M≈500: worst case all-pay ≈
+(1.25× / 0.1×). For N=4 heads and M≈500: worst case all-pay ≈
 $0.025/turn, perfect sharing ≈ $0.008/turn; capturing the contended delta
 (~$0.017/turn) would require ≥6s staggers. One fork's own cache-read at a
 100K context costs $0.10 on fable, so M-contention stays a single-digit %
-of observer spend.
+of observation spend.
 
 Real-session calibration (this repo's pi session: fable, xhigh thinking,
 96 requests, context grown to ~187K tokens, $19.04 driver cost):
@@ -202,20 +202,20 @@ Real-session calibration (this repo's pi session: fable, xhigh thinking,
 - Implementation note: fork-from-n must append M exactly as pi-ai serializes
   it in history, including thinking blocks and signatures, or the pre-warm
   entry won't match the driver's next prefix. Place the marker on M's last
-  text/tool_use block, never on a thinking block (API error). The observer
+  text/tool_use block, never on a thinking block (API error). The observation
   must also replay the driver's exact thinking config: per Anthropic's
   invalidation table, thinking-parameter changes invalidate the entire
   messages cache (hydra's byte-replay does this by construction). On
-  Opus 4.5+/Sonnet 4.6+-class models (incl. fable), appending the observer's
+  Opus 4.5+/Sonnet 4.6+-class models (incl. fable), appending the observation's
   user message after thinking-bearing M keeps the cache valid (thinking
   blocks preserved); on Haiku-class models prior thinking blocks are
-  stripped, but driver and observer strip symmetrically, so prefix parity
+  stripped, but driver and observation payloads strip symmetrically, so prefix parity
   survives.
 - Anthropic's sanctioned pre-warm (`max_tokens: 0`) cannot serve as a
   pointer-advancer for thinking-enabled drivers: it is rejected when thinking
   is enabled, and a no-thinking pre-warm would not share the messages cache
   (thinking-parameter mismatch invalidates it). Since any dedicated advancer
-  also pays 0.1× on the full prefix, the observer fork is the only viable and
+  also pays 0.1× on the full prefix, the observation fork is the only viable and
   only economical pointer-advancer.
 
 ### 7. Races are cost-neutral
@@ -227,7 +227,7 @@ with no other writer. A lost race wastes the pre-warm; it never adds cost.
 
 1. Fork from n, not n-1. The heuristic saves ~1.0–1.25× of a few hundred
    tokens (sub-millicent) and is the direct cause of stale observations.
-2. Put a cache_control marker on M in the observer payload: the observer's
+2. Put a cache_control marker on M in the observation payload: the observation's
    write pre-warms the driver's next turn (the driver reads M at 0.1× instead
    of writing it at 1.25×). Net system cost ≈ +0.1× of M. Mind the
    4-breakpoint request limit when adding it.
@@ -238,9 +238,9 @@ with no other writer. A lost race wastes the pre-warm; it never adds cost.
    pre-warm still works for human-paced turns (many seconds later), but
    auto-triggered immediate turns on large contexts should expect to race,
    cost-neutrally (see 7).
-4. Recommended delay: none, single or multi-observer. Fire all forks in
+4. Recommended delay: none, single or multiple heads. Fire all forks in
    parallel at run end, each with a marker on M. Rationale: (a) the contended
-   amount is only M; worst case for 4 observers ≈ $0.009/turn at Sonnet,
+   amount is only M; worst case for 4 heads ≈ $0.009/turn at Sonnet,
    while sharing perfectly saves ~$0.005, about 3% of one observation's own
    cache-read cost at a 100K context. (b) No fixed stagger is reliable at
    realistic context sizes (see prefix scaling). (c) Feedback latency is the
@@ -256,11 +256,11 @@ with no other writer. A lost race wastes the pre-warm; it never adds cost.
    Fable strengthens the no-delay call: visibility is writer TTFT (~3–5s on
    fable at small prefixes, more at large) plus ~zero propagation, so a
    reliable fixed stagger costs more latency than ever, while the contended
-   amount stays a single-digit % of observer spend. Driver pre-warm on fable
-   lands when the next turn starts after the observer's TTFT, still typical
+   amount stays a single-digit % of observation spend. Driver pre-warm on fable
+   lands when the next turn starts after the observation's TTFT, still typical
    for human-paced turns.
 
-   Multi-observer accounting, two framings, both true. Per-fork, races are
+   Multi-head accounting, two framings, both true. Per-fork, races are
    cost-neutral: no fork (or driver) ever pays above its solo no-sharing
    baseline. In aggregate, N simultaneous markered forks place N marker bets
    of which at most one is read by the driver: overhead +0.25N×M vs unmarked
@@ -275,14 +275,14 @@ with no other writer. A lost race wastes the pre-warm; it never adds cost.
 
    Mid-run turns: don't pre-warm the driver, piggyback on it. Inside a tool
    loop the driver fires request N+1 (containing M plus tool results) within
-   ms–seconds, usually inside the observer's TTFT, so a fork-from-n marker
+   ms–seconds, usually inside the observation's TTFT, so a fork-from-n marker
    bet is almost always wasted there. Invert it: observe at the driver's own
    commit point. pi sees `before_provider_request` (N+1 dispatched) and the
    response's `message_start` (the commit, no estimation needed); fire ALL
-   observers then, forked from N+1's captured payload plus observer prompt.
+   observations then, forked from N+1's captured payload plus observation prompt.
    Strictly dominant mid-run: a pure 0.1× read for M and the tool results
    (the driver paid the write anyway, so the "double pay" vanishes), a
-   fresher snapshot, zero coordination between observers, and the verdict
+   fresher snapshot, zero coordination between heads, and the verdict
    typically lands while response N+1 is still generating. Hybrid policy:
    mid-run, piggyback at the driver's commit; run-ending turn, fork-from-n
    with the marker on M, fired immediately. Implemented in `index.ts` and
@@ -292,15 +292,15 @@ with no other writer. A lost race wastes the pre-warm; it never adds cost.
    500ms grace guard was added, measured unnecessary, and deleted.
    Run-ending turns differ for one structural reason: there is no next driver
    request to ride on. Nobody will carry the final M into the cache until the
-   user's next prompt, so the observer must carry M itself; and because that
-   gap is human-paced (≫ observer TTFT), the marker bet reliably pays there.
+   user's next prompt, so the observation must carry M itself; and because that
+   gap is human-paced (≫ observation TTFT), the marker bet reliably pays there.
 
    Lookup mechanics per mode: the piggyback fork replays the driver's payload
    byte-identically (markers included) and appends its prompt unmarked. Its
    deepest breakpoint is the driver's own tail marker, an exact hit on the
    entry the driver just wrote: no walk-back, no new markers, no 4-breakpoint
    pressure. The run-end pre-warm is the one path that needs walk-back: the
-   driver's next request must find the observer's M-marker entry within the
+   driver's next request must find the observation's M-marker entry within the
    20-block lookback window; next user prompts add 1–2 blocks, comfortably
    inside. Verified live end-to-end (June 2026, cross-process `pi -p`
    sessions): the driver's next first request read prefix+M to the token

--- a/experiments/cache-latest-message.mjs
+++ b/experiments/cache-latest-message.mjs
@@ -6,9 +6,9 @@
  * Hypotheses:
  *   H1  The driver's latest assistant message M is NOT cached after the driver's
  *       own request completes (it was a response, never part of a sent prefix).
- *       An observer fork that includes M pays uncached input for it.
+ *       An observation fork that includes M pays uncached input for it.
  *   H2  A fork from n-1 (excluding M) is a pure cache read: creation ≈ 0,
- *       input ≈ observer prompt only. This holds for N parallel observers.
+ *       input ≈ observation prompt only. This holds for N parallel observations.
  *   H3  A fork including M with a cache_control marker ON M pays cache_creation
  *       for M once; a subsequent serial fork reads M from cache.
  *   H4  N PARALLEL forks including M (marker on M) each pay cache_creation,
@@ -49,11 +49,11 @@ const DRIVER_USER_MSG = {
   ],
 };
 
-// ~150-token observer prompts, hydra-style. Content varies per "lens" so the
+// ~150-token observation prompts, hydra-style. Content varies per "lens" so the
 // parallel requests are realistic (shared prefix, divergent suffix).
-function observerPrompt(lens) {
+function observationPrompt(lens) {
   return (
-    `<system-reminder>Side observer (${lens} lens). Reply with one JSON object, nothing else: ` +
+    `<system-reminder>Side watcher (${lens} lens). Reply with one JSON object, nothing else: ` +
     `{"action":"noop|queue|interrupt","reason":"≤120 chars","message":"≤240 chars, empty if noop"} ` +
     `Review the conversation through the ${lens} lens: focus on correctness risks, missing verification, ` +
     `dangerous assumptions, and obvious regressions. Noop unless something warrants feedback. ` +
@@ -61,12 +61,12 @@ function observerPrompt(lens) {
   );
 }
 
-function observerMsg(lens) {
-  return { role: "user", content: [{ type: "text", text: observerPrompt(lens) }] };
+function observationMsg(lens) {
+  return { role: "user", content: [{ type: "text", text: observationPrompt(lens) }] };
 }
 
 // Assistant message M (captured from the driver response), optionally with a
-// cache_control marker so observers can advance the cache breakpoint past M.
+// cache_control marker so observations can advance the cache breakpoint past M.
 function assistantMsg(text, withMarker = false) {
   const block = { type: "text", text };
   if (withMarker) block.cache_control = { type: "ephemeral" };
@@ -111,41 +111,41 @@ async function main() {
   logRow(p1);
   await sleep(PHASE_SLEEP_MS);
 
-  // ── P2: three PARALLEL n-1 observers (the original hydra behavior) ──
-  log("\n── P2: 3 parallel observers, fork from n-1 (exclude M) ──");
+  // ── P2: three PARALLEL n-1 observations (the original hydra behavior) ──
+  log("\n── P2: 3 parallel observations, fork from n-1 (exclude M) ──");
   const p2 = await Promise.all(
     ["quality", "security", "simplifier"].map((lens) =>
-      call(`P2 n-1 obs ${lens}`, [DRIVER_USER_MSG, observerMsg(lens)], 150)
+      call(`P2 n-1 obs ${lens}`, [DRIVER_USER_MSG, observationMsg(lens)], 150)
     )
   );
   p2.forEach(logRow);
   await sleep(PHASE_SLEEP_MS);
 
-  // ── P3: observer fork from n (includes M), NO new marker ──
-  log("\n── P3: observer fork from n (include M), no marker on M ──");
+  // ── P3: observation fork from n (includes M), NO new marker ──
+  log("\n── P3: observation fork from n (include M), no marker on M ──");
   const p3 = await call(
     "P3 n obs no-marker",
-    [DRIVER_USER_MSG, assistantMsg(M), observerMsg("quality")],
+    [DRIVER_USER_MSG, assistantMsg(M), observationMsg("quality")],
     150
   );
   logRow(p3);
   await sleep(PHASE_SLEEP_MS);
 
-  // ── P4a: three PARALLEL observers fork from n, marker ON M ──
-  log("\n── P4a: 3 parallel observers, fork from n, cache_control marker on M ──");
+  // ── P4a: three PARALLEL observations fork from n, marker ON M ──
+  log("\n── P4a: 3 parallel observations, fork from n, cache_control marker on M ──");
   const p4a = await Promise.all(
     ["quality", "security", "simplifier"].map((lens) =>
-      call(`P4a n obs+mark ${lens}`, [DRIVER_USER_MSG, assistantMsg(M, true), observerMsg(lens)], 150)
+      call(`P4a n obs+mark ${lens}`, [DRIVER_USER_MSG, assistantMsg(M, true), observationMsg(lens)], 150)
     )
   );
   p4a.forEach(logRow);
   await sleep(PHASE_SLEEP_MS);
 
-  // ── P4b: serial observer after the parallel writers ──
-  log("\n── P4b: serial observer fork from n, marker on M (after P4a settled) ──");
+  // ── P4b: serial observation after the parallel writers ──
+  log("\n── P4b: serial observation fork from n, marker on M (after P4a settled) ──");
   const p4b = await call(
     "P4b n obs+mark serial",
-    [DRIVER_USER_MSG, assistantMsg(M, true), observerMsg("api-design")],
+    [DRIVER_USER_MSG, assistantMsg(M, true), observationMsg("api-design")],
     150
   );
   logRow(p4b);
@@ -155,7 +155,7 @@ async function main() {
   const prefixTokens = p1.cacheRead; // full driver prefix as measured by replay
   const obsPromptTokens = Math.round(p2.reduce((sum, row) => sum + row.input, 0) / p2.length);
   const mTokens = p0.output; // output tokens of M ≈ its input cost when replayed
-  log(`measured: driver prefix ≈ ${prefixTokens}, observer prompt ≈ ${obsPromptTokens}, M (output) ≈ ${mTokens}\n`);
+  log(`measured: driver prefix ≈ ${prefixTokens}, observation prompt ≈ ${obsPromptTokens}, M (output) ≈ ${mTokens}\n`);
 
   let all = true;
 
@@ -195,11 +195,11 @@ async function main() {
   ) && all;
 
   // ── Cost model summary ──
-  log("\n══ Cost interpretation (per observer, for the latest-message tokens M) ══");
-  log("  fork n-1:                0, but the observer judges a stale snapshot");
-  log("  fork n, no marker:       1.0× input price for M, every observer, every turn");
-  log("  fork n, marker, serial:  1.25× once (first observer), 0.1× for later observers");
-  log(`  fork n, marker, parallel: ${writers === p4a.length ? "1.25× for EACH racing observer (no dedup)" : "partially deduped; see P4a rows"}`);
+  log("\n══ Cost interpretation (per observation, for the latest-message tokens M) ══");
+  log("  fork n-1:                0, but the observation judges a stale snapshot");
+  log("  fork n, no marker:       1.0× input price for M, every observation, every turn");
+  log("  fork n, marker, serial:  1.25× once (first observation), 0.1× for later observations");
+  log(`  fork n, marker, parallel: ${writers === p4a.length ? "1.25× for EACH racing observation (no dedup)" : "partially deduped; see P4a rows"}`);
 
   log(all ? "\nAll hypotheses confirmed." : "\nSome hypotheses NOT confirmed; read rows above.");
 }

--- a/experiments/cache-stagger.mjs
+++ b/experiments/cache-stagger.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * P4a refinement: 4 observer forks from n (marker on M). One fires at t=0,
+ * P4a refinement: 4 observation forks from n (marker on M). One fires at t=0,
  * three fire in parallel at t=+STAGGER_MS. Do the delayed forks free-ride on
  * the writer's cache entry?
  *
@@ -67,13 +67,13 @@ const DRIVER_USER_MSG = {
   }],
 };
 
-function observerMsg(lens) {
+function observationMsg(lens) {
   return {
     role: "user",
     content: [{
       type: "text",
       text:
-        `<system-reminder>Side observer (${lens} lens). Reply with one JSON object, nothing else: ` +
+        `<system-reminder>Side watcher (${lens} lens). Reply with one JSON object, nothing else: ` +
         `{"action":"noop|queue|interrupt","reason":"≤120 chars","message":"≤240 chars, empty if noop"} ` +
         `Noop unless something warrants feedback. No tools, no follow-up turn.</system-reminder>`,
     }],
@@ -145,7 +145,7 @@ async function main() {
   const mBlocks = driver.content.map((block, i) =>
     i === lastEligible ? { ...block, cache_control: { type: "ephemeral" } } : block
   );
-  const forkMessages = (lens) => [DRIVER_USER_MSG, { role: "assistant", content: mBlocks }, observerMsg(lens)];
+  const forkMessages = (lens) => [DRIVER_USER_MSG, { role: "assistant", content: mBlocks }, observationMsg(lens)];
   const forkMax = THINKING ? 1500 : 150;
 
   const tFire = Date.now();

--- a/experiments/cache-thinking-walkback.mjs
+++ b/experiments/cache-thinking-walkback.mjs
@@ -2,13 +2,13 @@
 /**
  * Walk-back lookup across thinking-bearing M (fable, adaptive thinking).
  *
- * The driver-pre-warm claim requires: after an observer writes `prefix+M`
+ * The driver-pre-warm claim requires: after an observation writes `prefix+M`
  * (marker on M), the driver's NEXT request (M *without* a marker, a new user
  * message *with* one) finds the entry via breakpoint walk-back. Verified on haiku without thinking; this verifies it with
  * thinking blocks (real signatures, replayed verbatim) in M.
  *
  *   1. driver cold (adaptive thinking) → M = [thinking, text] blocks
- *   2. writer: prefix + M(marker) + observer prompt → creates prefix+M entry
+ *   2. writer: prefix + M(marker) + observation prompt → creates prefix+M entry
  *   3. probe (driver-next-turn shape): prefix + M(no marker) + user(marker)
  *      Expect: read ≈ prefix + M (walk-back hit), write ≈ followup only.
  *

--- a/experiments/cache-timing.mjs
+++ b/experiments/cache-timing.mjs
@@ -3,7 +3,7 @@
  * When does an Anthropic prompt-cache write become READABLE?
  *
  * Companion to cache-latest-message.mjs. That experiment established (H3/H4):
- * an observer fork including the driver's latest assistant message M with a
+ * an observation fork including the driver's latest assistant message M with a
  * cache_control marker on M creates a readable `prefix+M` entry, eventually.
  * This experiment pins down WHEN: at writer request ingestion, mid-processing,
  * or only after response completion (+ propagation lag).
@@ -11,7 +11,7 @@
  * Why it matters for hydra: if the driver's next request starts inside the
  * commit window W, the driver misses the entry and pays for M itself (the
  * race). W bounds how soon a driver turn can start and still benefit from the
- * observer's pre-warm.
+ * observation's pre-warm.
  *
  * Method (single cold conversation, no probe self-contamination):
  *   - WRITER: prefix + M(cache_control) + prompt forcing a LONG response
@@ -80,7 +80,7 @@ async function main() {
   const mTokens = p0.output;
   await sleep(3000); // let prefix entries settle so probe misses read ≈ prefix cleanly
 
-  // WRITER: observer-style fork, marker ON M, long output to separate
+  // WRITER: observation-style fork, marker ON M, long output to separate
   // ingestion time from completion time. Fired WITHOUT await.
   const writerMessages = [
     DRIVER_USER_MSG,
@@ -187,8 +187,8 @@ async function main() {
       log(`→ Entry readable only AFTER writer completion: commit at response time.`);
     }
     log(`→ Race window for hydra: a driver request starting < ~${firstHit.sentAt}ms after the`);
-    log(`   observer fires misses the pre-warm and pays cache_creation for M itself (no extra`);
-    log(`   cost vs no observer; the write is simply not shared).`);
+    log(`   observation fires misses the pre-warm and pays cache_creation for M itself (no extra`);
+    log(`   cost vs no observation; the write is simply not shared).`);
   }
 }
 

--- a/index.ts
+++ b/index.ts
@@ -1,10 +1,10 @@
 /**
- * hydra: commit-point observer for pi.
+ * hydra: commit-point observation for pi.
  *
  * Watches the driver's conversation through a side model that replays the
- * driver's exact provider payload with one observer prompt appended. Because
+ * driver's exact provider payload with one observation prompt appended. Because
  * the prefix is byte-identical, every observation is a prompt-cache read of
- * the entry the driver itself just wrote (97%+ hit ratio). The observer
+ * the entry the driver itself just wrote (97%+ hit ratio). The head
  * answers with a JSON decision naming its finding's delivery (noop, print,
  * queue, steer, or interrupt) which hydra routes back into the session.
  *
@@ -23,7 +23,7 @@
  *   that produced it has just been committed to the cache. Replaying that
  *   request is a pure cache read, fresh through the latest tool results.
  * - Run-end (agent_end): no further driver request will carry the final
- *   assistant message M into the cache, so the observer appends M itself,
+ *   assistant message M into the cache, so the observation appends M itself,
  *   serialized by pi-ai's own provider code via the onPayload hook, and
  *   moves the driver's message-level cache marker onto it. The fork pays M's
  *   write once and pre-warms the driver's next, human-paced turn.
@@ -33,7 +33,7 @@
  *   /hydra-heads      no argument opens the picker; an argument sets the
  *                     active heads ("quality,security"), `none` clears them
  *   /hydra-stats      cache hit ratio, cost, and recent decisions
- *   /hydra-debug      dump driver/observer payload pairs for diffing
+ *   /hydra-debug      dump driver/observation payload pairs for diffing
  *
  * The agent manages head files like any other file and points the heads
  * through the registered `hydra` tool (add, remove). The active set is
@@ -59,13 +59,13 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Box, Key, matchesKey, Text, truncateToWidth } from "@earendil-works/pi-tui";
-import type { Action, AnthropicPayload, Decision, HeadDefinition, ObserverUsage } from "./utils";
+import type { Action, AnthropicPayload, Decision, HeadDefinition, ObservationUsage } from "./utils";
 import {
-	buildObserverPrompt,
+	buildObservationPrompt,
 	demoteStaleInterrupt,
 	headActs,
 	isAnthropicPayload,
-	mergeObserverPayload,
+	mergeObservationPayload,
 	parseDecision,
 	parseHeadFile,
 	parseHeadList,
@@ -93,7 +93,7 @@ const MAX_TOOL_ITERATIONS = 25;
 const DIAGNOSTIC_PROMPTS = {
 	test: `<system-reminder>Developer integration test for the hydra framework. The wrapper requires EXACTLY this output, with no preamble, no markdown, no thinking, no explanation:
 
-{"action":"queue","reason":"test fire","message":"hydra test observer fired (e2e pipeline verified)"}
+{"action":"queue","reason":"test fire","message":"hydra test head fired (e2e pipeline verified)"}
 
 This is not a real review. Output the JSON above byte-for-byte and stop.</system-reminder>`,
 	"test-interrupt": `<system-reminder>Developer integration test for hydra's interrupt path. Output EXACTLY this JSON, nothing else:
@@ -113,7 +113,7 @@ const EXECUTABLE_TOOL_NAMES = ["read", "bash", "edit", "write", "grep", "find", 
 
 const errorText = (error: unknown): string => (error instanceof Error ? error.message : String(error));
 
-// One observer call, persisted to the session as a custom "hydra-call" entry
+// One observation call, persisted to the session as a custom "hydra-call" entry
 // so /hydra-stats survives resume and branch navigation.
 interface HydraCall {
 	timestamp: number;
@@ -372,9 +372,9 @@ export default function hydraExtension(pi: ExtensionAPI) {
 		updateFooter(ctx);
 	}
 
-	function observerPromptFor(name: string, tools: string[] | undefined): string {
+	function observationPromptFor(name: string, tools: string[] | undefined): string {
 		const instruction = heads.get(name)?.prompt ?? "";
-		return buildObserverPrompt(name, instruction, tools);
+		return buildObservationPrompt(name, instruction, tools);
 	}
 
 	// A head's executable allowance: diagnostics never act; a head file's
@@ -516,12 +516,12 @@ export default function hydraExtension(pi: ExtensionAPI) {
 	// loop exits after one turn, so iterations stays 1.
 	interface ObserveOutcome {
 		response: AssistantMessage;
-		usages: ObserverUsage[];
+		usages: ObservationUsage[];
 		iterations: number;
 		toolsUsed: string[];
 	}
 
-	function flattenUsage(usage: AssistantMessage["usage"]): ObserverUsage {
+	function flattenUsage(usage: AssistantMessage["usage"]): ObservationUsage {
 		return {
 			input: usage.input,
 			output: usage.output,
@@ -561,19 +561,19 @@ export default function hydraExtension(pi: ExtensionAPI) {
 		// Run-end observations carry M so pi-ai's own provider code serializes
 		// it; piggyback payloads already contain everything. The onPayload hook
 		// receives pi-ai's serialization of these messages and splices it onto
-		// the captured prefix; see mergeObserverPayload for the cache story.
+		// the captured prefix; see mergeObservationPayload for the cache story.
 		const onPayload = (built: unknown) => {
 			if (!isAnthropicPayload(built)) {
 				throw new Error(`unexpected payload shape from provider ${model.provider}`);
 			}
-			const merged = mergeObserverPayload(captured, built.messages);
+			const merged = mergeObservationPayload(captured, built.messages);
 			if (debugDir) {
 				// A diagnostic must never kill the observation it diagnoses:
 				// on any write failure, drop the dump dir and keep observing.
 				const stem = `${Date.now()}-${job.head}-${debugSeq++}`;
 				try {
 					writeFileSync(join(debugDir, `hydra-driver-${stem}.json`), JSON.stringify(captured, null, 2));
-					writeFileSync(join(debugDir, `hydra-observer-${stem}.json`), JSON.stringify(merged, null, 2));
+					writeFileSync(join(debugDir, `hydra-observation-${stem}.json`), JSON.stringify(merged, null, 2));
 				} catch (error) {
 					debugDir = null;
 					job.ctx.ui.notify(`hydra: debug dump failed (${errorText(error)}); dumping disabled`, "warning");
@@ -583,7 +583,7 @@ export default function hydraExtension(pi: ExtensionAPI) {
 		};
 
 		const t0 = Date.now();
-		const outcome = await runObserverLoop(job, model, auth.apiKey, auth.headers, onPayload, signal);
+		const outcome = await runObservationLoop(job, model, auth.apiKey, auth.headers, onPayload, signal);
 		if (!outcome || signal.aborted) {
 			return;
 		}
@@ -593,7 +593,7 @@ export default function hydraExtension(pi: ExtensionAPI) {
 		// A zero-usage, zero-content response is a provider hiccup (e.g. an
 		// overload surfaced as an empty result), not an observation.
 		if (summary.input + summary.cacheRead + summary.cacheWrite === 0 && response.content.length === 0) {
-			notifyUser(job.ctx, "hydra: observer call returned empty response (provider overloaded?)", "warning");
+			notifyUser(job.ctx, "hydra: observation call returned empty response (provider overloaded?)", "warning");
 			return;
 		}
 
@@ -660,8 +660,8 @@ export default function hydraExtension(pi: ExtensionAPI) {
 	// provider call the loop makes flows through the same byte-true merge
 	// (onPayload discards the loop's own built context), so the driver
 	// prefix stays a pure cache read and any loop turns are cached once by
-	// the marker the merge advances; see mergeObserverPayload.
-	async function runObserverLoop(
+	// the marker the merge advances; see mergeObservationPayload.
+	async function runObservationLoop(
 		job: Observation,
 		model: Model<"anthropic-messages">,
 		apiKey: string,
@@ -674,14 +674,14 @@ export default function hydraExtension(pi: ExtensionAPI) {
 			content: [{ type: "text", text: job.prompt }],
 			timestamp: Date.now(),
 		};
-		const usages: ObserverUsage[] = [];
+		const usages: ObservationUsage[] = [];
 		const toolsUsed: string[] = [];
 		let iterations = 0;
 		let messages: Awaited<ReturnType<typeof runAgentLoop>>;
 		try {
 			messages = await runAgentLoop(
 				[prompt],
-				{ systemPrompt: "", messages: job.assistant ? [job.assistant] : [], tools: observerTools(job.ctx, job.tools) },
+				{ systemPrompt: "", messages: job.assistant ? [job.assistant] : [], tools: observationTools(job.ctx, job.tools) },
 				{
 					model,
 					apiKey,
@@ -715,19 +715,19 @@ export default function hydraExtension(pi: ExtensionAPI) {
 			);
 		} catch (error) {
 			if (!signal.aborted) {
-				notifyUser(job.ctx, `hydra: observer loop failed: ${errorText(error)}`, "error");
+				notifyUser(job.ctx, `hydra: observation loop failed: ${errorText(error)}`, "error");
 			}
 			return null;
 		}
 
 		const response = [...messages].reverse().find((message): message is AssistantMessage => message.role === "assistant");
 		if (!response) {
-			notifyUser(job.ctx, "hydra: observer loop produced no response", "warning");
+			notifyUser(job.ctx, "hydra: observation loop produced no response", "warning");
 			return null;
 		}
 		if (response.stopReason === "error" || response.stopReason === "aborted") {
 			if (!signal.aborted) {
-				notifyUser(job.ctx, `hydra: observer loop failed: ${response.errorMessage ?? "aborted"}`, "error");
+				notifyUser(job.ctx, `hydra: observation loop failed: ${response.errorMessage ?? "aborted"}`, "error");
 			}
 			return null;
 		}
@@ -737,7 +737,7 @@ export default function hydraExtension(pi: ExtensionAPI) {
 		return { response, usages, iterations, toolsUsed };
 	}
 
-	// The observer executes through pi's own tool implementations at the
+	// The head executes through pi's own tool implementations at the
 	// driver's cwd. write/edit serialize same-file mutations through pi's
 	// process-wide per-file queue, shared with the driver because the
 	// extension loader aliases @earendil-works/pi-coding-agent to its bundled
@@ -746,10 +746,10 @@ export default function hydraExtension(pi: ExtensionAPI) {
 	// itself. A head file's `tools:` list narrows what actually executes; a
 	// call outside the list (or to another extension's tool, or MCP) gets
 	// pi's standard "tool not found" error result and the head moves on.
-	let standardObserverTools: AgentTool[] | null = null;
-	function observerTools(ctx: ExtensionContext, allowed: string[] | undefined): AgentTool[] {
-		if (!standardObserverTools) {
-			standardObserverTools = [
+	let standardObservationTools: AgentTool[] | null = null;
+	function observationTools(ctx: ExtensionContext, allowed: string[] | undefined): AgentTool[] {
+		if (!standardObservationTools) {
+			standardObservationTools = [
 				createReadTool(ctx.cwd),
 				createBashTool(ctx.cwd),
 				createEditTool(ctx.cwd),
@@ -762,7 +762,7 @@ export default function hydraExtension(pi: ExtensionAPI) {
 		// Plus hydra's own tool: an acting head may re-crew its peers through
 		// the same tool the driver uses.
 		const all = [
-			...standardObserverTools,
+			...standardObservationTools,
 			{
 				name: hydraToolDefinition.name,
 				label: hydraToolDefinition.label,
@@ -775,16 +775,16 @@ export default function hydraExtension(pi: ExtensionAPI) {
 		return allowed === undefined ? all : all.filter((tool) => allowed.includes(tool.name));
 	}
 
-	// Every observer file write also queues a one-line note, so the driver is
+	// Every head file write also queues a one-line note, so the driver is
 	// never surprised by files changing under it. Provenance rather than a
-	// finding. Writes that happen inside the observer's bash commands are
+	// finding. Writes that happen inside the head's bash commands are
 	// invisible here; documented limitation.
 	function announceWrite(job: Observation, toolCall: ToolCall) {
 		if (toolCall.name !== "write" && toolCall.name !== "edit") {
 			return;
 		}
 		const path = typeof toolCall.arguments.path === "string" ? toolCall.arguments.path : "a file";
-		const details: FeedbackDetails = { head: job.head, action: "queue", reason: "observer file write" };
+		const details: FeedbackDetails = { head: job.head, action: "queue", reason: "head file write" };
 		pi.sendMessage(
 			{
 				customType: "hydra-feedback",
@@ -801,7 +801,7 @@ export default function hydraExtension(pi: ExtensionAPI) {
 			return;
 		}
 
-		// The observer reviews overlapping snapshots, so identical findings
+		// A head reviews overlapping snapshots, so identical findings
 		// recur; deliver each one once per head. Diagnostic heads are exempt:
 		// their message is fixed by design, and every smoke-test firing must be
 		// visible.
@@ -896,7 +896,7 @@ export default function hydraExtension(pi: ExtensionAPI) {
 				assistant,
 				turnIndex: currentTurnIndex,
 				head: name,
-				prompt: observerPromptFor(name, tools),
+				prompt: observationPromptFor(name, tools),
 				tools,
 				kind,
 			};
@@ -1045,7 +1045,7 @@ export default function hydraExtension(pi: ExtensionAPI) {
 	// The agent's hand on the head set. Head files themselves are the
 	// agent's to manage with its ordinary file tools; this tool only points
 	// the heads, which is the one piece of state not on disk. The definition
-	// is named so acting heads can execute it too (observerTools).
+	// is named so acting heads can execute it too (observationTools).
 	const hydraToolParameters = Type.Object({
 		action: StringEnum(["add", "remove"] as const, { description: "What to do" }),
 		head: Type.String({ description: "The head name" }),
@@ -1055,7 +1055,7 @@ export default function hydraExtension(pi: ExtensionAPI) {
 		name: "hydra",
 		label: "Hydra",
 		description: [
-			"Point your hydra observer heads: `add` puts a head on the active set,",
+			"Point your hydra heads: `add` puts a head on the active set,",
 			"`remove` takes it off (both idempotent; the set is session state). Each",
 			"active head independently reviews your full context as you work. Heads",
 			`are markdown files in ${userHeadDir} (user) and .pi/hydra (project):`,
@@ -1231,7 +1231,7 @@ export default function hydraExtension(pi: ExtensionAPI) {
 	});
 
 	pi.registerCommand("hydra-stats", {
-		description: "Show hydra observer statistics",
+		description: "Show hydra observation statistics",
 		handler: async (_args, ctx) => {
 			if (calls.length === 0) {
 				ctx.ui.notify("hydra: no observations yet", "info");

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/spannagel/dev/personal/pi-hydra/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/spannagel/dev/personal/pi-hydra/node_modules

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pi-hydra",
 	"version": "0.1.0",
-	"description": "Extra heads for your pi coding agent: real-time observers at prompt-cache prices",
+	"description": "Extra heads for your pi coding agent: real-time observation at prompt-cache prices",
 	"keywords": [
 		"pi-package",
 		"pi",

--- a/utils.test.ts
+++ b/utils.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
 import type { AnthropicPayload, PayloadBlock, PayloadMessage } from "./utils";
 import {
-	buildObserverPrompt,
+	buildObservationPrompt,
 	demoteStaleInterrupt,
 	headActs,
 	isAnthropicPayload,
 	isValidHeadName,
-	mergeObserverPayload,
+	mergeObservationPayload,
 	parseDecision,
 	parseHeadFile,
 	parseHeadList,
@@ -107,24 +107,24 @@ describe("headActs", () => {
 	});
 });
 
-describe("buildObserverPrompt", () => {
+describe("buildObservationPrompt", () => {
 	it("bans tools for a judge-only head", () => {
-		const prompt = buildObserverPrompt("quality", "Judge.", []);
+		const prompt = buildObservationPrompt("quality", "Judge.", []);
 		expect(prompt).toContain("No tools");
 		expect(prompt).not.toContain("tool access");
 	});
 
 	it("spells out a narrowed allowance", () => {
-		const prompt = buildObserverPrompt("docs", "Keep notes.", ["read", "write"]);
+		const prompt = buildObservationPrompt("docs", "Keep notes.", ["read", "write"]);
 		expect(prompt).toContain("only these tools: read, write");
 	});
 
 	it("permits everything when tools are omitted", () => {
-		expect(buildObserverPrompt("docs", "Keep notes.", undefined)).toContain("the available tools");
+		expect(buildObservationPrompt("docs", "Keep notes.", undefined)).toContain("the available tools");
 	});
 });
 
-describe("mergeObserverPayload", () => {
+describe("mergeObservationPayload", () => {
 	const capturedFixture = (): AnthropicPayload => ({
 		model: "claude-test",
 		system: [{ type: "text", text: "sys", cache_control: { type: "ephemeral" } }],
@@ -153,7 +153,7 @@ describe("mergeObserverPayload", () => {
 			},
 			promptTail(),
 		];
-		const merged = mergeObserverPayload(capturedFixture(), tail);
+		const merged = mergeObservationPayload(capturedFixture(), tail);
 
 		expect(blocks(merged.messages[2])[1].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
 
@@ -175,7 +175,7 @@ describe("mergeObserverPayload", () => {
 			},
 			promptTail(),
 		];
-		const merged = mergeObserverPayload(capturedFixture(), tail);
+		const merged = mergeObservationPayload(capturedFixture(), tail);
 		const assistantBlocks = blocks(merged.messages[2]);
 		expect(assistantBlocks[0].cache_control).toBeUndefined();
 		expect(assistantBlocks[1].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
@@ -192,14 +192,14 @@ describe("mergeObserverPayload", () => {
 			},
 			promptTail(),
 		];
-		const merged = mergeObserverPayload(capturedFixture(), tail);
+		const merged = mergeObservationPayload(capturedFixture(), tail);
 		const assistantBlocks = blocks(merged.messages[2]);
 		expect(assistantBlocks[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
 		expect(assistantBlocks[1].cache_control).toBeUndefined();
 	});
 
 	it("leaves captured markers untouched when the tail has no markable assistant", () => {
-		const merged = mergeObserverPayload(capturedFixture(), [promptTail()]);
+		const merged = mergeObservationPayload(capturedFixture(), [promptTail()]);
 
 		expect(blocks(merged.messages[1])[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
 		expect(blocks(merged.messages[2])[0].cache_control).toBeUndefined();
@@ -210,7 +210,7 @@ describe("mergeObserverPayload", () => {
 			{ role: "assistant", content: [{ type: "thinking", thinking: "only", signature: "sig" }] },
 			promptTail(),
 		];
-		const merged = mergeObserverPayload(capturedFixture(), tail);
+		const merged = mergeObservationPayload(capturedFixture(), tail);
 		expect(blocks(merged.messages[1])[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
 	});
 
@@ -224,7 +224,7 @@ describe("mergeObserverPayload", () => {
 			},
 			{ role: "user", content: [{ type: "tool_result", tool_use_id: "t1", content: [] }] },
 		];
-		const merged = mergeObserverPayload(capturedFixture(), tail);
+		const merged = mergeObservationPayload(capturedFixture(), tail);
 		// Loop entries only need to survive until the next iteration: plain
 		// ephemeral, not the driver's 1h TTL. The prefix+M entry from the
 		// first call keeps serving the driver bet.
@@ -240,7 +240,7 @@ describe("mergeObserverPayload", () => {
 			{ role: "assistant", content: [{ type: "tool_use", id: "t1", name: "bash", input: {} }] },
 			{ role: "user", content: [{ type: "tool_result", tool_use_id: "t1", content: [] }] },
 		];
-		const merged = mergeObserverPayload(capturedFixture(), tail);
+		const merged = mergeObservationPayload(capturedFixture(), tail);
 		expect(blocks(merged.messages[4])[0].cache_control).toEqual({ type: "ephemeral" });
 		expect(blocks(merged.messages[3]).every((block) => block.cache_control === undefined)).toBe(true);
 	});
@@ -253,7 +253,7 @@ describe("mergeObserverPayload", () => {
 			{ role: "assistant", content: [{ type: "text", text: "final" }] },
 			promptTail(),
 		];
-		const merged = mergeObserverPayload(captured, tail);
+		const merged = mergeObservationPayload(captured, tail);
 		expect(blocks(merged.messages[1])[0].cache_control).toEqual({ type: "ephemeral" });
 	});
 
@@ -268,7 +268,7 @@ describe("mergeObserverPayload", () => {
 			{ role: "user", content: [{ type: "tool_result", tool_use_id: "t1", content: [] }] },
 		];
 		for (const tail of [[promptTail()], [loopTail[0], promptTail()], loopTail]) {
-			expect(countMarkers(mergeObserverPayload(captured, tail))).toBeLessThanOrEqual(countMarkers(captured));
+			expect(countMarkers(mergeObservationPayload(captured, tail))).toBeLessThanOrEqual(countMarkers(captured));
 		}
 	});
 
@@ -280,7 +280,7 @@ describe("mergeObserverPayload", () => {
 		];
 		const capturedBefore = structuredClone(captured);
 		const tailBefore = structuredClone(tail);
-		mergeObserverPayload(captured, tail);
+		mergeObservationPayload(captured, tail);
 		expect(captured).toEqual(capturedBefore);
 		expect(tail).toEqual(tailBefore);
 	});

--- a/utils.ts
+++ b/utils.ts
@@ -1,5 +1,5 @@
 /**
- * Pure helpers for the hydra observer.
+ * Pure helpers for hydra observations.
  * Extracted for testability; no pi or I/O dependencies.
  */
 
@@ -53,7 +53,7 @@ function tryParseDecision(text: string): Decision | null {
 }
 
 /**
- * Parse the observer's JSON decision, tolerating code fences and surrounding
+ * Parse the head's JSON decision, tolerating code fences and surrounding
  * prose. Null means nothing parseable: the caller decides how loudly a head
  * that stopped speaking JSON should fail.
  */
@@ -104,7 +104,7 @@ export function rememberDelivery(delivered: Set<string>, key: string, max: numbe
 	return true;
 }
 
-export interface ObserverUsage {
+export interface ObservationUsage {
 	input: number;
 	output: number;
 	cacheRead: number;
@@ -119,7 +119,7 @@ export interface ObserverUsage {
  * iteration alone, since that is the replay-parity regression signal and
  * later iterations legitimately pay the loop tail as fresh input.
  */
-export function summarizeLoopUsage(usages: ObserverUsage[]): ObserverUsage & { hitRatio: number } {
+export function summarizeLoopUsage(usages: ObservationUsage[]): ObservationUsage & { hitRatio: number } {
 	const total = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0 };
 	for (const usage of usages) {
 		total.input += usage.input;
@@ -216,23 +216,23 @@ const DECISION_SHAPE = '{"action":"noop|print|queue|steer|interrupt","reason":"\
 
 /**
  * The wrapper around a head's instruction. Kept SHORT: the driver's context
- * is already cached, so this is the only fresh input the observer pays for
- * per call. Judge-only heads (tools: []) get a hard tool ban: the observer
+ * is already cached, so this is the only fresh input the observation pays for
+ * per call. Judge-only heads (tools: []) get a hard tool ban: the head
  * sits atop a context saturated with driver tool calls, and anything softer
  * leaks into "let me check" excursions. Acting heads get the tool-permitting
  * variant, with the allowance spelled out when the file narrows it.
  */
-export function buildObserverPrompt(head: string, instruction: string, tools: string[] | undefined): string {
+export function buildObservationPrompt(head: string, instruction: string, tools: string[] | undefined): string {
 	if (headActs(tools)) {
 		const allowance = tools === undefined ? "the available tools" : `only these tools: ${tools.join(", ")}`;
-		return `<system-reminder>Side observer with tool access. You may use ${allowance} to check facts or act on your lens; the main agent does not see your tool calls, only files you change and the decision you send. When done, reply with one JSON object, nothing else:
+		return `<system-reminder>Side watcher with tool access. You may use ${allowance} to check facts or act on your lens; the main agent does not see your tool calls, only files you change and the decision you send. When done, reply with one JSON object, nothing else:
 ${DECISION_SHAPE}
 
 LENS: ${instruction}
 
 Noop when your work product is the files you wrote. Print a note the user sees but the agent does not. Queue findings that can wait. Steer to put a finding in front of the agent between turns. Interrupt only for emergencies that must stop the line. Don't prefix message with [${head}].</system-reminder>`;
 	}
-	return `<system-reminder>Side observer. Reply with one JSON object, nothing else:
+	return `<system-reminder>Side watcher. Reply with one JSON object, nothing else:
 ${DECISION_SHAPE}
 
 LENS: ${instruction}
@@ -288,7 +288,7 @@ export interface FinalAssistantCandidate {
  * Pick the run's final assistant message M for the run-end fork: the last
  * usable assistant message, required to BE the captured request's own
  * response. Anything else is already serialized inside the captured payload,
- * and appending it again would duplicate it in the observer's context. Runs
+ * and appending it again would duplicate it in the observation's context. Runs
  * whose final generation aborted or errored hit exactly that case and select
  * nothing.
  *
@@ -407,7 +407,7 @@ function lastMarkableBlockOfTail(tail: PayloadMessage[]): PayloadBlock | undefin
 }
 
 /**
- * Merge the observer tail (pi-ai's own serialization of `[M?, prompt,
+ * Merge the observation tail (pi-ai's own serialization of `[M?, prompt,
  * ...tool-loop turns]`) onto the captured driver payload.
  *
  * The captured prefix is replayed byte-true so the fork reads the driver's
@@ -421,7 +421,7 @@ function lastMarkableBlockOfTail(tail: PayloadMessage[]): PayloadBlock | undefin
  * - `[M, prompt]`: a run-end fork. The driver's marker (TTL included) rides
  *   M's last markable block: the fork's write pre-warms the driver's next
  *   request, which finds the prefix+M entry via breakpoint walk-back.
- * - longer: a tool loop appended observer turns. The marker advances to the
+ * - longer: a tool loop appended observation turns. The marker advances to the
  *   tail's last markable block, so each loop turn is written once and read
  *   thereafter instead of re-paid as input every iteration. A plain
  *   ephemeral marker, deliberately without the driver's TTL: loop entries
@@ -430,7 +430,7 @@ function lastMarkableBlockOfTail(tail: PayloadMessage[]): PayloadBlock | undefin
  *
  * Markers pi-ai placed on the tail are dropped before any of this.
  */
-export function mergeObserverPayload(captured: AnthropicPayload, tail: PayloadMessage[]): AnthropicPayload {
+export function mergeObservationPayload(captured: AnthropicPayload, tail: PayloadMessage[]): AnthropicPayload {
 	const merged = structuredClone(captured) as AnthropicPayload;
 	// Clone the tail before touching it: it is pi-ai's own params object, and
 	// the marker handling below must not reach back into it. Markers pi-ai


### PR DESCRIPTION
## What this changes

Three commits, reviewable independently:

1. **Compare heads to subagents** — carries over the section that was sitting uncommitted in the working tree. Drop this commit if it wasn't ready.
2. **Cost story + Limitations.** The README stated the ~1% per-observation price three times and never the session aggregate. Real accrued costs measure roughly +30% per always-on head per session, because a head observes at every cache commit. New `What it costs` section holds both numbers plus measured cache hit rates (97%+ fleet, 99% on the 17K reference); the intro and the comparison table now state per-observation and per-session side by side; the detailed numbers move out of `Why`. New `Limitations` section collects what was scattered: Anthropic-only, model-locked heads, the mid-stream blind spot, session cost.
3. **Voice pass.** Cuts sentences whose job was quotability, not information (the production-incident escalation, "pay for themselves", "still molten", the assembly-line simile) and removes em dashes. Product vocabulary (heads, the cord, one body many heads) untouched.

## Why now

The AI Tinkerers Cologne talk (Jul 15) will send builders here who fact-check cost claims. The repo's standard is measured-not-assumed; the headline cost number should meet it.

## Judgment calls to review

- Intro now carries both numbers (1% per observation, ~30% per session). Alternative was keeping the intro light and deferring to the section.
- "Caught in production, an incident" was cut as rhetorical escalation — restore it if you consider the third stage information.
- The 99% cache claim is kept but scoped to the 17K reference measurement, with 97%+ stated as the fleet number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)