### PR TITLE
hydra: resolve the observation transport through pi's provider overrides

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -932,11 +932,20 @@ export default function hydraExtension(pi: ExtensionAPI) {
 			return merged;
 		};
 
+		// pi's runtime substitutes an auth-supplied baseUrl into the model before
+		// streaming (model-runtime: `{ ...model, baseUrl: resolution.auth.baseUrl }`),
+		// and the transports read `model.baseUrl`. `ctx.model` is the unsubstituted
+		// session model, so without this an observation would bypass a gateway the
+		// driver's own requests go through. Read defensively: `baseUrl` is absent
+		// from this result before pi 0.84.
+		const authBaseUrl = (auth as { baseUrl?: string }).baseUrl;
+		const observationModel = authBaseUrl ? { ...model, baseUrl: authBaseUrl } : model;
+
 		const t0 = Date.now();
 		const outcome =
 			job.completionMode === "enum"
-				? await runJudgeObservation(job, model, auth.apiKey, auth.headers, codexSessionId, onPayload, signal)
-				: await runObservationLoop(job, model, auth.apiKey, auth.headers, codexSessionId, onPayload, signal);
+				? await runJudgeObservation(job, observationModel, auth.apiKey, auth.headers, codexSessionId, onPayload, signal)
+				: await runObservationLoop(job, observationModel, auth.apiKey, auth.headers, codexSessionId, onPayload, signal);
 		if (!outcome || signal.aborted || job.branchGeneration !== branchGeneration) {
 			return;
 		}

--- a/index.ts
+++ b/index.ts
@@ -937,9 +937,13 @@ export default function hydraExtension(pi: ExtensionAPI) {
 		// and the transports read `model.baseUrl`. `ctx.model` is the unsubstituted
 		// session model, so without this an observation would bypass a gateway the
 		// driver's own requests go through. Read defensively: `baseUrl` is absent
-		// from this result before pi 0.84.
-		const authBaseUrl = (auth as { baseUrl?: string }).baseUrl;
-		const observationModel = authBaseUrl ? { ...model, baseUrl: authBaseUrl } : model;
+		// from this result before pi 0.84, and the cast below is only a compile-time
+		// assertion, so check the value rather than trusting its declared type.
+		const authBaseUrl = (auth as { baseUrl?: unknown }).baseUrl;
+		const observationModel =
+			typeof authBaseUrl === "string" && authBaseUrl.length > 0
+				? { ...model, baseUrl: authBaseUrl }
+				: model;
 
 		const t0 = Date.now();
 		const outcome =

--- a/index.ts
+++ b/index.ts
@@ -51,7 +51,7 @@ import { dirname, join } from "node:path";
 import { runAgentLoop, uuidv7 } from "@earendil-works/pi-agent-core";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { cleanupSessionResources } from "@earendil-works/pi-ai";
-import type { AssistantMessage, Message, Model, ToolCall } from "@earendil-works/pi-ai";
+import type { Api, AssistantMessage, Message, Model, ToolCall } from "@earendil-works/pi-ai";
 import { streamSimple } from "@earendil-works/pi-ai/compat";
 import {
 	createBashTool,
@@ -114,6 +114,67 @@ import {
 	summarizeLoopUsage,
 	usesSplitObservationHandoff,
 } from "./utils";
+
+/**
+ * Resolve a model's transport from pi's registered provider overrides, falling
+ * back to pi-ai's compat helper.
+ *
+ * `compat.streamSimple` always reaches the builtin provider: pi 0.82 keeps
+ * extension provider overrides in its own model runtime and never calls
+ * pi-ai's `registerApiProvider`, so pi-ai's api registry only ever holds
+ * builtins. A provider-wrapping extension therefore shapes the driver's
+ * requests -- which resolve through pi's runtime -- while remaining invisible
+ * to a direct `streamSimple` call here. Observations then reach the provider
+ * unshaped and are billed and classified differently from the very turns they
+ * are observing.
+ *
+ * `getRegisteredProviderConfig` is the reachable seam: it returns the
+ * `ProviderConfigInput` an extension registered, whose optional `streamSimple`
+ * is the wrapper. Resolving per call keeps this correct when an extension
+ * registers late or re-registers, and the fallback keeps hydra working when
+ * nothing has registered an override at all.
+ */
+function resolveStreamSimple(ctx: ExtensionContext, model: Model<Api>): typeof streamSimple {
+	// `getRegisteredProviderConfig` is not a documented extension surface, so
+	// treat every part of it as optional: a pi version without it, or with a
+	// different shape, must fall back rather than throw inside every
+	// observation.
+	const registry = ctx.modelRegistry as {
+		getRegisteredProviderConfig?: (provider: string) => { api?: string; streamSimple?: unknown } | undefined;
+	};
+	if (typeof registry.getRegisteredProviderConfig !== "function") return streamSimple;
+	const config = registry.getRegisteredProviderConfig(model.provider);
+	// Mirror pi's own composition guard (composeModelProvider): an extension's
+	// transport applies only to the api it registered for. Using it for another
+	// api would send a request through a transport that never expected it.
+	if (typeof config?.streamSimple !== "function" || config.api !== model.api) return streamSimple;
+	return config.streamSimple as typeof streamSimple;
+}
+
+/**
+ * Explain an observation failure that a missing transport override can cause.
+ *
+ * Having no override is the normal case -- most setups load no
+ * provider-wrapping extension -- so its absence is not warnable on its own. It
+ * only becomes a diagnosis when an observation is actually rejected: then the
+ * likely cause is that an extension shapes the driver's requests while hydra's
+ * observations bypass it, so only the observations reach the provider
+ * unshaped.
+ *
+ * Takes the transport actually used rather than re-deriving it, so the hint
+ * cannot disagree with the call it is describing, and concurrent observations
+ * cannot report each other's transport.
+ */
+function observationFailureHint(transport: typeof streamSimple, message: string): string {
+	if (transport !== streamSimple) return "";
+	// Only diagnose rejections that look like the provider refusing the request
+	// itself. Transient failures (overload, network, abort) say nothing about
+	// transport resolution, and most setups legitimately have no override.
+	const looksLikeRejection = /\b400\b|invalid_request_error|extra usage|unauthorized|authentication/i.test(message);
+	return looksLikeRejection
+		? " (no provider transport override was resolved; if an extension shapes this provider's requests, hydra's observations are bypassing it)"
+		: "";
+}
 
 // How long session_shutdown waits for an in-flight observation before
 // aborting it. Headless runs (`pi -p`) exit right after agent_end, so slow
@@ -1008,6 +1069,7 @@ export default function hydraExtension(pi: ExtensionAPI) {
 		onPayload: (built: unknown) => unknown,
 		signal: AbortSignal,
 	): Promise<ObserveOutcome | null> {
+		const transport = resolveStreamSimple(job.ctx, model);
 		const prompt: Message = {
 			role: "user",
 			content: [{ type: "text", text: job.prompt }],
@@ -1037,7 +1099,7 @@ export default function hydraExtension(pi: ExtensionAPI) {
 				onPayload,
 				signal,
 			};
-			const response = await streamSimple(model, { systemPrompt: "", messages, tools: [] }, options).result();
+			const response = await transport(model, { systemPrompt: "", messages, tools: [] }, options).result();
 			usages.push(flattenUsage(response.usage));
 			return response;
 		};
@@ -1047,7 +1109,11 @@ export default function hydraExtension(pi: ExtensionAPI) {
 			response = await call([...baseMessages, prompt]);
 			if (signal.aborted || response.stopReason === "error" || response.stopReason === "aborted") {
 				if (!signal.aborted) {
-					notifyUser(job.ctx, `hydra: observation failed: ${response.errorMessage ?? response.stopReason}`, "error");
+					notifyUser(
+						job.ctx,
+						`hydra: observation failed: ${response.errorMessage ?? response.stopReason}${observationFailureHint(transport, response.errorMessage ?? "")}`,
+						"error",
+					);
 				}
 				return null;
 			}
@@ -1066,7 +1132,7 @@ export default function hydraExtension(pi: ExtensionAPI) {
 			};
 		} catch (error) {
 			if (!signal.aborted) {
-				notifyUser(job.ctx, `hydra: observation failed: ${errorText(error)}`, "error");
+				notifyUser(job.ctx, `hydra: observation failed: ${errorText(error)}${observationFailureHint(transport, errorText(error))}`, "error");
 			}
 			return null;
 		}
@@ -1090,6 +1156,7 @@ export default function hydraExtension(pi: ExtensionAPI) {
 		onPayload: (built: unknown) => unknown,
 		signal: AbortSignal,
 	): Promise<ObserveOutcome | null> {
+		const transport = resolveStreamSimple(job.ctx, model);
 		const prompt: Message = {
 			role: "user",
 			content: [{ type: "text", text: job.prompt }],
@@ -1229,11 +1296,15 @@ export default function hydraExtension(pi: ExtensionAPI) {
 					}
 					},
 					signal,
-					streamSimple,
+					transport,
 				);
 		} catch (error) {
 			if (!signal.aborted) {
-				notifyUser(job.ctx, `hydra: observation loop failed: ${errorText(error)}`, "error");
+				notifyUser(
+					job.ctx,
+					`hydra: observation loop failed: ${errorText(error)}${observationFailureHint(transport, errorText(error))}`,
+					"error",
+				);
 			}
 			return null;
 		}
@@ -1245,7 +1316,11 @@ export default function hydraExtension(pi: ExtensionAPI) {
 		}
 		if (response.stopReason === "error" || response.stopReason === "aborted") {
 			if (!signal.aborted) {
-				notifyUser(job.ctx, `hydra: observation loop failed: ${response.errorMessage ?? "aborted"}`, "error");
+				notifyUser(
+					job.ctx,
+					`hydra: observation loop failed: ${response.errorMessage ?? "aborted"}${observationFailureHint(transport, response.errorMessage ?? "")}`,
+					"error",
+				);
 			}
 			return null;
 		}

--- a/index.ts
+++ b/index.ts
@@ -51,7 +51,7 @@ import { dirname, join } from "node:path";
 import { runAgentLoop, uuidv7 } from "@earendil-works/pi-agent-core";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { cleanupSessionResources } from "@earendil-works/pi-ai";
-import type { Api, AssistantMessage, Message, Model, ToolCall } from "@earendil-works/pi-ai";
+import type { Api, AssistantMessage, Message, Model, ProviderHeaders, ToolCall } from "@earendil-works/pi-ai";
 import { streamSimple } from "@earendil-works/pi-ai/compat";
 import {
 	createBashTool,
@@ -1060,11 +1060,14 @@ export default function hydraExtension(pi: ExtensionAPI) {
 	// Judge-only heads make one provider call with no executable tools. ENUM's
 	// measured fail-open contract records malformed output as noop; it never
 	// spends a recovery turn or silently infers a partial list.
+	// `headers` is ProviderHeaders: since pi 0.84 a null value is a header-deletion
+	// marker, not an absent header. Forward them unchanged, as pi documents --
+	// filtering or coercing here would resurrect a header pi intends to delete.
 	async function runJudgeObservation(
 		job: Observation,
 		model: Model<"anthropic-messages" | "openai-codex-responses">,
 		apiKey: string,
-		headers: Record<string, string> | undefined,
+		headers: ProviderHeaders | undefined,
 		sessionId: string | undefined,
 		onPayload: (built: unknown) => unknown,
 		signal: AbortSignal,
@@ -1151,7 +1154,7 @@ export default function hydraExtension(pi: ExtensionAPI) {
 		job: Observation,
 		model: Model<"anthropic-messages" | "openai-codex-responses">,
 		apiKey: string,
-		headers: Record<string, string> | undefined,
+		headers: ProviderHeaders | undefined,
 		sessionId: string | undefined,
 		onPayload: (built: unknown) => unknown,
 		signal: AbortSignal,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,4877 +1,5033 @@
 {
- "name": "pi-hydra",
- "version": "0.1.0",
- "lockfileVersion": 3,
- "requires": true,
- "packages": {
-  "": {
-   "name": "pi-hydra",
-   "version": "0.1.0",
-   "license": "MIT",
-   "devDependencies": {
-    "@earendil-works/pi-agent-core": "0.82.0",
-    "@types/node": "^22",
-    "typescript": "^5.7",
-    "vitest": "^3"
-   },
-   "peerDependencies": {
-    "@earendil-works/pi-agent-core": "*",
-    "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*",
-    "@earendil-works/pi-tui": "*"
-   }
-  },
-  "node_modules/@anthropic-ai/sdk": {
-   "version": "0.91.1",
-   "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
-   "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
-   "license": "MIT",
-   "dependencies": {
-    "json-schema-to-ts": "^3.1.1"
-   },
-   "bin": {
-    "anthropic-ai-sdk": "bin/cli"
-   },
-   "peerDependencies": {
-    "zod": "^3.25.0 || ^4.0.0"
-   },
-   "peerDependenciesMeta": {
-    "zod": {
-     "optional": true
-    }
-   }
-  },
-  "node_modules/@aws-crypto/sha256-browser": {
-   "version": "5.2.0",
-   "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-   "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@aws-crypto/sha256-js": "^5.2.0",
-    "@aws-crypto/supports-web-crypto": "^5.2.0",
-    "@aws-crypto/util": "^5.2.0",
-    "@aws-sdk/types": "^3.222.0",
-    "@aws-sdk/util-locate-window": "^3.0.0",
-    "@smithy/util-utf8": "^2.0.0",
-    "tslib": "^2.6.2"
-   }
-  },
-  "node_modules/@aws-crypto/sha256-js": {
-   "version": "5.2.0",
-   "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-   "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@aws-crypto/util": "^5.2.0",
-    "@aws-sdk/types": "^3.222.0",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=16.0.0"
-   }
-  },
-  "node_modules/@aws-crypto/supports-web-crypto": {
-   "version": "5.2.0",
-   "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-   "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "tslib": "^2.6.2"
-   }
-  },
-  "node_modules/@aws-crypto/util": {
-   "version": "5.2.0",
-   "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-   "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@aws-sdk/types": "^3.222.0",
-    "@smithy/util-utf8": "^2.0.0",
-    "tslib": "^2.6.2"
-   }
-  },
-  "node_modules/@aws-sdk/client-bedrock-runtime": {
-   "version": "3.1048.0",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
-   "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@aws-crypto/sha256-browser": "5.2.0",
-    "@aws-crypto/sha256-js": "5.2.0",
-    "@aws-sdk/core": "^3.974.11",
-    "@aws-sdk/credential-provider-node": "^3.972.42",
-    "@aws-sdk/eventstream-handler-node": "^3.972.16",
-    "@aws-sdk/middleware-eventstream": "^3.972.12",
-    "@aws-sdk/middleware-websocket": "^3.972.19",
-    "@aws-sdk/token-providers": "3.1048.0",
-    "@aws-sdk/types": "^3.973.8",
-    "@smithy/core": "^3.24.2",
-    "@smithy/fetch-http-handler": "^5.4.2",
-    "@smithy/node-http-handler": "^4.7.2",
-    "@smithy/types": "^4.14.1",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@aws-sdk/core": {
-   "version": "3.975.1",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.1.tgz",
-   "integrity": "sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@aws-sdk/types": "^3.974.0",
-    "@aws-sdk/xml-builder": "^3.972.34",
-    "@aws/lambda-invoke-store": "^0.3.0",
-    "@smithy/core": "^3.29.2",
-    "@smithy/signature-v4": "^5.6.3",
-    "@smithy/types": "^4.16.0",
-    "bowser": "^2.11.0",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@aws-sdk/credential-provider-env": {
-   "version": "3.972.57",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.57.tgz",
-   "integrity": "sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@aws-sdk/core": "^3.975.1",
-    "@aws-sdk/types": "^3.974.0",
-    "@smithy/core": "^3.29.2",
-    "@smithy/types": "^4.16.0",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@aws-sdk/credential-provider-http": {
-   "version": "3.972.59",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.59.tgz",
-   "integrity": "sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@aws-sdk/core": "^3.975.1",
-    "@aws-sdk/types": "^3.974.0",
-    "@smithy/core": "^3.29.2",
-    "@smithy/fetch-http-handler": "^5.6.4",
-    "@smithy/node-http-handler": "^4.9.4",
-    "@smithy/types": "^4.16.0",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-   "version": "4.9.5",
-   "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.5.tgz",
-   "integrity": "sha512-bNqdxTQTxmLbomSmlkZFz8L6B/feQ2HHzw4L2zY7Ecp2XffYAZq2uzdWDdxJHJFbEvqd+SRuluJso0P8+xPdbw==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@smithy/core": "^3.29.3",
-    "@smithy/types": "^4.16.1",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=18.0.0"
-   }
-  },
-  "node_modules/@aws-sdk/credential-provider-ini": {
-   "version": "3.973.1",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.1.tgz",
-   "integrity": "sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@aws-sdk/core": "^3.975.1",
-    "@aws-sdk/credential-provider-env": "^3.972.57",
-    "@aws-sdk/credential-provider-http": "^3.972.59",
-    "@aws-sdk/credential-provider-login": "^3.972.63",
-    "@aws-sdk/credential-provider-process": "^3.972.57",
-    "@aws-sdk/credential-provider-sso": "^3.973.1",
-    "@aws-sdk/credential-provider-web-identity": "^3.972.63",
-    "@aws-sdk/nested-clients": "^3.997.31",
-    "@aws-sdk/types": "^3.974.0",
-    "@smithy/core": "^3.29.2",
-    "@smithy/credential-provider-imds": "^4.4.7",
-    "@smithy/types": "^4.16.0",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@aws-sdk/credential-provider-login": {
-   "version": "3.972.63",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.63.tgz",
-   "integrity": "sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@aws-sdk/core": "^3.975.1",
-    "@aws-sdk/nested-clients": "^3.997.31",
-    "@aws-sdk/types": "^3.974.0",
-    "@smithy/core": "^3.29.2",
-    "@smithy/types": "^4.16.0",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@aws-sdk/credential-provider-node": {
-   "version": "3.972.66",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.66.tgz",
-   "integrity": "sha512-f+qjRXZpz7sgzbc4QB+6nLKfyKFgRRXzWdXbsKPv/VhVRyHsDyq4yBWC/B75BAJpFIcUeI2XR/3gdWJ677zB4A==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@aws-sdk/credential-provider-env": "^3.972.57",
-    "@aws-sdk/credential-provider-http": "^3.972.59",
-    "@aws-sdk/credential-provider-ini": "^3.973.1",
-    "@aws-sdk/credential-provider-process": "^3.972.57",
-    "@aws-sdk/credential-provider-sso": "^3.973.1",
-    "@aws-sdk/credential-provider-web-identity": "^3.972.63",
-    "@aws-sdk/types": "^3.974.0",
-    "@smithy/core": "^3.29.2",
-    "@smithy/credential-provider-imds": "^4.4.7",
-    "@smithy/types": "^4.16.0",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@aws-sdk/credential-provider-process": {
-   "version": "3.972.57",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.57.tgz",
-   "integrity": "sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@aws-sdk/core": "^3.975.1",
-    "@aws-sdk/types": "^3.974.0",
-    "@smithy/core": "^3.29.2",
-    "@smithy/types": "^4.16.0",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@aws-sdk/credential-provider-sso": {
-   "version": "3.973.1",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.1.tgz",
-   "integrity": "sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@aws-sdk/core": "^3.975.1",
-    "@aws-sdk/nested-clients": "^3.997.31",
-    "@aws-sdk/token-providers": "3.1083.0",
-    "@aws-sdk/types": "^3.974.0",
-    "@smithy/core": "^3.29.2",
-    "@smithy/types": "^4.16.0",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-   "version": "3.1083.0",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1083.0.tgz",
-   "integrity": "sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@aws-sdk/core": "^3.975.1",
-    "@aws-sdk/nested-clients": "^3.997.31",
-    "@aws-sdk/types": "^3.974.0",
-    "@smithy/core": "^3.29.2",
-    "@smithy/types": "^4.16.0",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@aws-sdk/credential-provider-web-identity": {
-   "version": "3.972.63",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.63.tgz",
-   "integrity": "sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@aws-sdk/core": "^3.975.1",
-    "@aws-sdk/nested-clients": "^3.997.31",
-    "@aws-sdk/types": "^3.974.0",
-    "@smithy/core": "^3.29.2",
-    "@smithy/types": "^4.16.0",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@aws-sdk/eventstream-handler-node": {
-   "version": "3.972.26",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.26.tgz",
-   "integrity": "sha512-RE1fu7Nn05vG0EUJM+8Sde2GFecC658WGaC/asPzLF6K4x3H5ZaDBcQtHRE67Gdgb1VZpyUUliYejHFK1qt0Uw==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@aws-sdk/types": "^3.974.0",
-    "@smithy/core": "^3.29.2",
-    "@smithy/types": "^4.16.0",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@aws-sdk/middleware-eventstream": {
-   "version": "3.972.22",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.22.tgz",
-   "integrity": "sha512-jtkgmhevnpzC1WeS+Y/sgymYbaQ6qg7pVOUl5cUT/8MiLptqrtnXQlNV80m+j2WIx5MIL7kVHIZNxxcK2tfUEQ==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@aws-sdk/types": "^3.974.0",
-    "@smithy/core": "^3.29.2",
-    "@smithy/types": "^4.16.0",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@aws-sdk/middleware-websocket": {
-   "version": "3.972.39",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.39.tgz",
-   "integrity": "sha512-CS1spxRSezmTmI3PD+3Xrnp6KryTSEz0EefA8u6uGd0s2I0uXseWHALDI/03Wi0IUczXNWo2QrZEaHDuJNby/Q==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@aws-sdk/core": "^3.975.1",
-    "@aws-sdk/types": "^3.974.0",
-    "@smithy/core": "^3.29.2",
-    "@smithy/fetch-http-handler": "^5.6.4",
-    "@smithy/signature-v4": "^5.6.3",
-    "@smithy/types": "^4.16.0",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">= 14.0.0"
-   }
-  },
-  "node_modules/@aws-sdk/nested-clients": {
-   "version": "3.997.31",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.31.tgz",
-   "integrity": "sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@aws-sdk/core": "^3.975.1",
-    "@aws-sdk/signature-v4-multi-region": "^3.996.39",
-    "@aws-sdk/types": "^3.974.0",
-    "@smithy/core": "^3.29.2",
-    "@smithy/fetch-http-handler": "^5.6.4",
-    "@smithy/node-http-handler": "^4.9.4",
-    "@smithy/types": "^4.16.0",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-   "version": "4.9.5",
-   "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.5.tgz",
-   "integrity": "sha512-bNqdxTQTxmLbomSmlkZFz8L6B/feQ2HHzw4L2zY7Ecp2XffYAZq2uzdWDdxJHJFbEvqd+SRuluJso0P8+xPdbw==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@smithy/core": "^3.29.3",
-    "@smithy/types": "^4.16.1",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=18.0.0"
-   }
-  },
-  "node_modules/@aws-sdk/signature-v4-multi-region": {
-   "version": "3.996.39",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.39.tgz",
-   "integrity": "sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@aws-sdk/types": "^3.974.0",
-    "@smithy/signature-v4": "^5.6.3",
-    "@smithy/types": "^4.16.0",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@aws-sdk/token-providers": {
-   "version": "3.1048.0",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
-   "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@aws-sdk/core": "^3.974.11",
-    "@aws-sdk/nested-clients": "^3.997.9",
-    "@aws-sdk/types": "^3.973.8",
-    "@smithy/core": "^3.24.2",
-    "@smithy/types": "^4.14.1",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@aws-sdk/types": {
-   "version": "3.974.0",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.0.tgz",
-   "integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@smithy/types": "^4.16.0",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@aws-sdk/util-locate-window": {
-   "version": "3.965.8",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz",
-   "integrity": "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@aws-sdk/xml-builder": {
-   "version": "3.972.34",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
-   "integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@smithy/types": "^4.16.0",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@aws/lambda-invoke-store": {
-   "version": "0.3.0",
-   "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
-   "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
-   "license": "Apache-2.0",
-   "engines": {
-    "node": ">=18.0.0"
-   }
-  },
-  "node_modules/@babel/runtime": {
-   "version": "7.29.7",
-   "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
-   "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-   "license": "MIT",
-   "engines": {
-    "node": ">=6.9.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-agent-core": {
-   "version": "0.82.0",
-   "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.82.0.tgz",
-   "integrity": "sha512-bnS9DpOKK5T/F/gQkaOnYdMsuuciWiScfAHHWC+k5OQ0HxjSqMFQvp8keurULLoT4+v8NHv4V14pNvd4hsfC0Q==",
-   "dev": true,
-   "license": "MIT",
-   "dependencies": {
-    "@earendil-works/pi-ai": "^0.82.0",
-    "diff": "8.0.4",
-    "ignore": "7.0.5",
-    "typebox": "1.1.38",
-    "yaml": "2.9.0"
-   },
-   "engines": {
-    "node": ">=22.19.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-ai": {
-   "version": "0.82.0",
-   "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.0.tgz",
-   "integrity": "sha512-8MvW9+zno13sXDuT2kFMnWeTNUufUhPeZDRVO+igGoBRCDWgn7Xh2FkRQI1mRuet6QhF4ENQuLYdIAOyG6BhNw==",
-   "license": "MIT",
-   "dependencies": {
-    "@anthropic-ai/sdk": "0.91.1",
-    "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-    "@google/genai": "1.52.0",
-    "@mistralai/mistralai": "2.2.6",
-    "@opentelemetry/api": "1.9.0",
-    "@smithy/node-http-handler": "4.7.3",
-    "http-proxy-agent": "7.0.2",
-    "https-proxy-agent": "7.0.6",
-    "openai": "6.26.0",
-    "partial-json": "0.1.7",
-    "typebox": "1.1.38"
-   },
-   "bin": {
-    "pi-ai": "dist/cli.js"
-   },
-   "engines": {
-    "node": ">=22.19.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent": {
-   "version": "0.82.0",
-   "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.82.0.tgz",
-   "integrity": "sha512-Qnqgn9zhJFQ2HZ8R4iNuGhyCk93XX6+eUw9i+TjTuo47amzCy93ft3bB6yaUCleCrNO58dJDHYSGNHv/GAPWKg==",
-   "hasShrinkwrap": true,
-   "license": "MIT",
-   "peer": true,
-   "dependencies": {
-    "@earendil-works/pi-agent-core": "^0.82.0",
-    "@earendil-works/pi-ai": "^0.82.0",
-    "@earendil-works/pi-tui": "^0.82.0",
-    "@silvia-odwyer/photon-node": "0.3.4",
-    "chalk": "5.6.2",
-    "cross-spawn": "7.0.6",
-    "diff": "8.0.4",
-    "glob": "13.0.6",
-    "highlight.js": "10.7.3",
-    "hosted-git-info": "9.0.3",
-    "ignore": "7.0.5",
-    "jiti": "2.7.0",
-    "minimatch": "10.2.5",
-    "proper-lockfile": "4.1.2",
-    "semver": "7.8.0",
-    "typebox": "1.1.38",
-    "undici": "8.5.0",
-    "yaml": "2.9.0"
-   },
-   "bin": {
-    "pi": "dist/cli.js"
-   },
-   "engines": {
-    "node": ">=22.19.0"
-   },
-   "optionalDependencies": {
-    "@mariozechner/clipboard": "0.3.9"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
-   "version": "0.91.1",
-   "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
-   "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
-   "license": "MIT",
-   "peer": true,
-   "dependencies": {
-    "json-schema-to-ts": "^3.1.1"
-   },
-   "bin": {
-    "anthropic-ai-sdk": "bin/cli"
-   },
-   "peerDependencies": {
-    "zod": "^3.25.0 || ^4.0.0"
-   },
-   "peerDependenciesMeta": {
-    "zod": {
-     "optional": true
-    }
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
-   "version": "5.2.0",
-   "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
-   "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@aws-crypto/util": "^5.2.0",
-    "@aws-sdk/types": "^3.222.0",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=16.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
-   "version": "5.2.0",
-   "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-   "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@aws-crypto/sha256-js": "^5.2.0",
-    "@aws-crypto/supports-web-crypto": "^5.2.0",
-    "@aws-crypto/util": "^5.2.0",
-    "@aws-sdk/types": "^3.222.0",
-    "@aws-sdk/util-locate-window": "^3.0.0",
-    "@smithy/util-utf8": "^2.0.0",
-    "tslib": "^2.6.2"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
-   "version": "5.2.0",
-   "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-   "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@aws-crypto/util": "^5.2.0",
-    "@aws-sdk/types": "^3.222.0",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=16.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
-   "version": "5.2.0",
-   "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-   "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "tslib": "^2.6.2"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
-   "version": "5.2.0",
-   "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-   "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@aws-sdk/types": "^3.222.0",
-    "@smithy/util-utf8": "^2.0.0",
-    "tslib": "^2.6.2"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
-   "version": "3.1048.0",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
-   "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@aws-crypto/sha256-browser": "5.2.0",
-    "@aws-crypto/sha256-js": "5.2.0",
-    "@aws-sdk/core": "^3.974.11",
-    "@aws-sdk/credential-provider-node": "^3.972.42",
-    "@aws-sdk/eventstream-handler-node": "^3.972.16",
-    "@aws-sdk/middleware-eventstream": "^3.972.12",
-    "@aws-sdk/middleware-websocket": "^3.972.19",
-    "@aws-sdk/token-providers": "3.1048.0",
-    "@aws-sdk/types": "^3.973.8",
-    "@smithy/core": "^3.24.2",
-    "@smithy/fetch-http-handler": "^5.4.2",
-    "@smithy/node-http-handler": "^4.7.2",
-    "@smithy/types": "^4.14.1",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
-   "version": "3.974.11",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
-   "integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@aws-sdk/types": "^3.973.8",
-    "@aws-sdk/xml-builder": "^3.972.24",
-    "@aws/lambda-invoke-store": "^0.2.2",
-    "@smithy/core": "^3.24.2",
-    "@smithy/signature-v4": "^5.4.2",
-    "@smithy/types": "^4.14.1",
-    "bowser": "^2.11.0",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
-   "version": "3.972.37",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
-   "integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@aws-sdk/core": "^3.974.11",
-    "@aws-sdk/types": "^3.973.8",
-    "@smithy/core": "^3.24.2",
-    "@smithy/types": "^4.14.1",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
-   "version": "3.972.39",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
-   "integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@aws-sdk/core": "^3.974.11",
-    "@aws-sdk/types": "^3.973.8",
-    "@smithy/core": "^3.24.2",
-    "@smithy/fetch-http-handler": "^5.4.2",
-    "@smithy/node-http-handler": "^4.7.2",
-    "@smithy/types": "^4.14.1",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
-   "version": "3.972.41",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
-   "integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@aws-sdk/core": "^3.974.11",
-    "@aws-sdk/credential-provider-env": "^3.972.37",
-    "@aws-sdk/credential-provider-http": "^3.972.39",
-    "@aws-sdk/credential-provider-login": "^3.972.41",
-    "@aws-sdk/credential-provider-process": "^3.972.37",
-    "@aws-sdk/credential-provider-sso": "^3.972.41",
-    "@aws-sdk/credential-provider-web-identity": "^3.972.41",
-    "@aws-sdk/nested-clients": "^3.997.9",
-    "@aws-sdk/types": "^3.973.8",
-    "@smithy/core": "^3.24.2",
-    "@smithy/credential-provider-imds": "^4.3.2",
-    "@smithy/types": "^4.14.1",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
-   "version": "3.972.41",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
-   "integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@aws-sdk/core": "^3.974.11",
-    "@aws-sdk/nested-clients": "^3.997.9",
-    "@aws-sdk/types": "^3.973.8",
-    "@smithy/core": "^3.24.2",
-    "@smithy/types": "^4.14.1",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
-   "version": "3.972.42",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
-   "integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@aws-sdk/credential-provider-env": "^3.972.37",
-    "@aws-sdk/credential-provider-http": "^3.972.39",
-    "@aws-sdk/credential-provider-ini": "^3.972.41",
-    "@aws-sdk/credential-provider-process": "^3.972.37",
-    "@aws-sdk/credential-provider-sso": "^3.972.41",
-    "@aws-sdk/credential-provider-web-identity": "^3.972.41",
-    "@aws-sdk/types": "^3.973.8",
-    "@smithy/core": "^3.24.2",
-    "@smithy/credential-provider-imds": "^4.3.2",
-    "@smithy/types": "^4.14.1",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
-   "version": "3.972.37",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
-   "integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@aws-sdk/core": "^3.974.11",
-    "@aws-sdk/types": "^3.973.8",
-    "@smithy/core": "^3.24.2",
-    "@smithy/types": "^4.14.1",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
-   "version": "3.972.41",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
-   "integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@aws-sdk/core": "^3.974.11",
-    "@aws-sdk/nested-clients": "^3.997.9",
-    "@aws-sdk/token-providers": "3.1048.0",
-    "@aws-sdk/types": "^3.973.8",
-    "@smithy/core": "^3.24.2",
-    "@smithy/types": "^4.14.1",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
-   "version": "3.972.41",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
-   "integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@aws-sdk/core": "^3.974.11",
-    "@aws-sdk/nested-clients": "^3.997.9",
-    "@aws-sdk/types": "^3.973.8",
-    "@smithy/core": "^3.24.2",
-    "@smithy/types": "^4.14.1",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
-   "version": "3.972.16",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
-   "integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@aws-sdk/types": "^3.973.8",
-    "@smithy/core": "^3.24.2",
-    "@smithy/types": "^4.14.1",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
-   "version": "3.972.12",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
-   "integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@aws-sdk/types": "^3.973.8",
-    "@smithy/core": "^3.24.2",
-    "@smithy/types": "^4.14.1",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
-   "version": "3.972.19",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
-   "integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@aws-sdk/core": "^3.974.11",
-    "@aws-sdk/types": "^3.973.8",
-    "@smithy/core": "^3.24.2",
-    "@smithy/fetch-http-handler": "^5.4.2",
-    "@smithy/signature-v4": "^5.4.2",
-    "@smithy/types": "^4.14.1",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">= 14.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
-   "version": "3.997.9",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
-   "integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@aws-crypto/sha256-browser": "5.2.0",
-    "@aws-crypto/sha256-js": "5.2.0",
-    "@aws-sdk/core": "^3.974.11",
-    "@aws-sdk/signature-v4-multi-region": "^3.996.27",
-    "@aws-sdk/types": "^3.973.8",
-    "@smithy/core": "^3.24.2",
-    "@smithy/fetch-http-handler": "^5.4.2",
-    "@smithy/node-http-handler": "^4.7.2",
-    "@smithy/types": "^4.14.1",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
-   "version": "3.996.27",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
-   "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@aws-sdk/types": "^3.973.8",
-    "@smithy/core": "^3.24.2",
-    "@smithy/signature-v4": "^5.4.2",
-    "@smithy/types": "^4.14.1",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
-   "version": "3.1048.0",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
-   "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@aws-sdk/core": "^3.974.11",
-    "@aws-sdk/nested-clients": "^3.997.9",
-    "@aws-sdk/types": "^3.973.8",
-    "@smithy/core": "^3.24.2",
-    "@smithy/types": "^4.14.1",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
-   "version": "3.973.8",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
-   "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@smithy/types": "^4.14.1",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
-   "version": "3.965.5",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
-   "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
-   "version": "3.972.24",
-   "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
-   "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@nodable/entities": "2.1.0",
-    "@smithy/types": "^4.14.1",
-    "fast-xml-parser": "5.7.3",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
-   "version": "0.2.4",
-   "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
-   "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "engines": {
-    "node": ">=18.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
-   "version": "7.29.2",
-   "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-   "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-   "license": "MIT",
-   "peer": true,
-   "engines": {
-    "node": ">=6.9.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-   "version": "0.82.0",
-   "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.82.0.tgz",
-   "license": "MIT",
-   "peer": true,
-   "dependencies": {
-    "@earendil-works/pi-ai": "^0.82.0",
-    "diff": "8.0.4",
-    "ignore": "7.0.5",
-    "typebox": "1.1.38",
-    "yaml": "2.9.0"
-   },
-   "engines": {
-    "node": ">=22.19.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-   "version": "0.82.0",
-   "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.0.tgz",
-   "license": "MIT",
-   "peer": true,
-   "dependencies": {
-    "@anthropic-ai/sdk": "0.91.1",
-    "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-    "@google/genai": "1.52.0",
-    "@mistralai/mistralai": "2.2.6",
-    "@opentelemetry/api": "1.9.0",
-    "@smithy/node-http-handler": "4.7.3",
-    "http-proxy-agent": "7.0.2",
-    "https-proxy-agent": "7.0.6",
-    "openai": "6.26.0",
-    "partial-json": "0.1.7",
-    "typebox": "1.1.38"
-   },
-   "bin": {
-    "pi-ai": "dist/cli.js"
-   },
-   "engines": {
-    "node": ">=22.19.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-   "version": "0.82.0",
-   "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.82.0.tgz",
-   "license": "MIT",
-   "peer": true,
-   "dependencies": {
-    "get-east-asian-width": "1.6.0",
-    "marked": "18.0.5"
-   },
-   "engines": {
-    "node": ">=22.19.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
-   "version": "1.52.0",
-   "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
-   "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
-   "hasInstallScript": true,
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "google-auth-library": "^10.3.0",
-    "p-retry": "^4.6.2",
-    "protobufjs": "^7.5.4",
-    "ws": "^8.18.0"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   },
-   "peerDependencies": {
-    "@modelcontextprotocol/sdk": "^1.25.2"
-   },
-   "peerDependenciesMeta": {
-    "@modelcontextprotocol/sdk": {
-     "optional": true
-    }
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
-   "version": "0.3.9",
-   "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
-   "integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
-   "license": "MIT",
-   "optional": true,
-   "peer": true,
-   "engines": {
-    "node": ">= 10"
-   },
-   "optionalDependencies": {
-    "@mariozechner/clipboard-darwin-arm64": "0.3.9",
-    "@mariozechner/clipboard-darwin-universal": "0.3.9",
-    "@mariozechner/clipboard-darwin-x64": "0.3.9",
-    "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
-    "@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
-    "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
-    "@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
-    "@mariozechner/clipboard-linux-x64-musl": "0.3.9",
-    "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
-    "@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
-   "version": "0.3.9",
-   "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
-   "integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
-   "cpu": [
-    "arm64"
-   ],
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "darwin"
-   ],
-   "peer": true,
-   "engines": {
-    "node": ">= 10"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
-   "version": "0.3.9",
-   "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
-   "integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "darwin"
-   ],
-   "peer": true,
-   "engines": {
-    "node": ">= 10"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
-   "version": "0.3.9",
-   "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
-   "integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
-   "cpu": [
-    "x64"
-   ],
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "darwin"
-   ],
-   "peer": true,
-   "engines": {
-    "node": ">= 10"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
-   "version": "0.3.9",
-   "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
-   "integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
-   "cpu": [
-    "arm64"
-   ],
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "linux"
-   ],
-   "peer": true,
-   "engines": {
-    "node": ">= 10"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
-   "version": "0.3.9",
-   "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
-   "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
-   "cpu": [
-    "arm64"
-   ],
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "linux"
-   ],
-   "peer": true,
-   "engines": {
-    "node": ">= 10"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
-   "version": "0.3.9",
-   "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
-   "integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
-   "cpu": [
-    "riscv64"
-   ],
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "linux"
-   ],
-   "peer": true,
-   "engines": {
-    "node": ">= 10"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
-   "version": "0.3.9",
-   "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
-   "integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
-   "cpu": [
-    "x64"
-   ],
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "linux"
-   ],
-   "peer": true,
-   "engines": {
-    "node": ">= 10"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
-   "version": "0.3.9",
-   "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
-   "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
-   "cpu": [
-    "x64"
-   ],
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "linux"
-   ],
-   "peer": true,
-   "engines": {
-    "node": ">= 10"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
-   "version": "0.3.9",
-   "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
-   "integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
-   "cpu": [
-    "arm64"
-   ],
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "win32"
-   ],
-   "peer": true,
-   "engines": {
-    "node": ">= 10"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
-   "version": "0.3.9",
-   "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
-   "integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
-   "cpu": [
-    "x64"
-   ],
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "win32"
-   ],
-   "peer": true,
-   "engines": {
-    "node": ">= 10"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
-   "version": "2.2.6",
-   "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-   "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@opentelemetry/semantic-conventions": "^1.40.0",
-    "ws": "^8.18.0",
-    "zod": "^3.25.0 || ^4.0.0",
-    "zod-to-json-schema": "^3.25.0"
-   },
-   "peerDependencies": {
-    "@opentelemetry/api": "^1.9.0"
-   },
-   "peerDependenciesMeta": {
-    "@opentelemetry/api": {
-     "optional": true
-    }
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
-   "version": "2.1.0",
-   "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-   "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
-   "funding": [
-    {
-     "type": "github",
-     "url": "https://github.com/sponsors/nodable"
-    }
-   ],
-   "license": "MIT",
-   "peer": true
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
-   "version": "1.9.0",
-   "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-   "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "engines": {
-    "node": ">=8.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
-   "version": "1.41.1",
-   "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-   "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "engines": {
-    "node": ">=14"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
-   "version": "1.1.2",
-   "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-   "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-   "license": "BSD-3-Clause",
-   "peer": true
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
-   "version": "1.1.2",
-   "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-   "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-   "license": "BSD-3-Clause",
-   "peer": true
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
-   "version": "2.0.5",
-   "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
-   "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-   "license": "BSD-3-Clause",
-   "peer": true
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
-   "version": "1.1.1",
-   "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
-   "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
-   "license": "BSD-3-Clause",
-   "peer": true
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
-   "version": "1.1.1",
-   "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
-   "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
-   "license": "BSD-3-Clause",
-   "peer": true,
-   "dependencies": {
-    "@protobufjs/aspromise": "^1.1.1"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
-   "version": "1.0.2",
-   "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-   "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-   "license": "BSD-3-Clause",
-   "peer": true
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
-   "version": "1.1.2",
-   "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-   "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-   "license": "BSD-3-Clause",
-   "peer": true
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
-   "version": "1.1.0",
-   "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-   "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-   "license": "BSD-3-Clause",
-   "peer": true
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
-   "version": "1.1.1",
-   "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-   "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-   "license": "BSD-3-Clause",
-   "peer": true
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
-   "version": "0.3.4",
-   "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
-   "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
-   "license": "Apache-2.0",
-   "peer": true
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
-   "version": "3.24.3",
-   "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
-   "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@aws-crypto/crc32": "5.2.0",
-    "@smithy/types": "^4.14.2",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=18.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
-   "version": "4.3.3",
-   "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
-   "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@smithy/core": "^3.24.3",
-    "@smithy/types": "^4.14.2",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=18.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
-   "version": "5.4.3",
-   "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
-   "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@smithy/core": "^3.24.3",
-    "@smithy/types": "^4.14.2",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=18.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
-   "version": "2.2.0",
-   "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-   "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=14.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
-   "version": "4.7.3",
-   "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
-   "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@smithy/core": "^3.24.3",
-    "@smithy/types": "^4.14.2",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=18.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
-   "version": "5.4.3",
-   "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
-   "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@smithy/core": "^3.24.3",
-    "@smithy/types": "^4.14.2",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=18.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
-   "version": "4.14.2",
-   "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
-   "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=18.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
-   "version": "2.2.0",
-   "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-   "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@smithy/is-array-buffer": "^2.2.0",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=14.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
-   "version": "2.3.0",
-   "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-   "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "@smithy/util-buffer-from": "^2.2.0",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=14.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
-   "version": "22.19.19",
-   "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-   "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
-   "license": "MIT",
-   "peer": true,
-   "dependencies": {
-    "undici-types": "~6.21.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
-   "version": "7.1.4",
-   "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-   "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-   "license": "MIT",
-   "peer": true,
-   "engines": {
-    "node": ">= 14"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
-   "version": "4.0.4",
-   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-   "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-   "license": "MIT",
-   "peer": true,
-   "engines": {
-    "node": "18 || 20 || >=22"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
-   "version": "1.5.1",
-   "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-   "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-   "funding": [
-    {
-     "type": "github",
-     "url": "https://github.com/sponsors/feross"
-    },
-    {
-     "type": "patreon",
-     "url": "https://www.patreon.com/feross"
-    },
-    {
-     "type": "consulting",
-     "url": "https://feross.org/support"
-    }
-   ],
-   "license": "MIT",
-   "peer": true
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
-   "version": "9.3.1",
-   "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-   "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
-   "license": "MIT",
-   "peer": true,
-   "engines": {
-    "node": "*"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
-   "version": "2.14.1",
-   "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
-   "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
-   "license": "MIT",
-   "peer": true
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
-   "version": "5.0.7",
-   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-   "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
-   "license": "MIT",
-   "peer": true,
-   "dependencies": {
-    "balanced-match": "^4.0.2"
-   },
-   "engines": {
-    "node": "18 || 20 || >=22"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
-   "version": "1.0.1",
-   "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-   "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-   "license": "BSD-3-Clause",
-   "peer": true
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
-   "version": "5.6.2",
-   "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-   "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-   "license": "MIT",
-   "peer": true,
-   "engines": {
-    "node": "^12.17.0 || ^14.13 || >=16.0.0"
-   },
-   "funding": {
-    "url": "https://github.com/chalk/chalk?sponsor=1"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/cross-spawn": {
-   "version": "7.0.6",
-   "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-   "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-   "license": "MIT",
-   "peer": true,
-   "dependencies": {
-    "path-key": "^3.1.0",
-    "shebang-command": "^2.0.0",
-    "which": "^2.0.1"
-   },
-   "engines": {
-    "node": ">= 8"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
-   "version": "4.0.1",
-   "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-   "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-   "license": "MIT",
-   "peer": true,
-   "engines": {
-    "node": ">= 12"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
-   "version": "4.4.3",
-   "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-   "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-   "license": "MIT",
-   "peer": true,
-   "dependencies": {
-    "ms": "^2.1.3"
-   },
-   "engines": {
-    "node": ">=6.0"
-   },
-   "peerDependenciesMeta": {
-    "supports-color": {
-     "optional": true
-    }
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
-   "version": "8.0.4",
-   "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-   "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-   "license": "BSD-3-Clause",
-   "peer": true,
-   "engines": {
-    "node": ">=0.3.1"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
-   "version": "1.0.11",
-   "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-   "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "safe-buffer": "^5.0.1"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
-   "version": "3.0.2",
-   "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-   "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-   "license": "MIT",
-   "peer": true
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
-   "version": "1.2.0",
-   "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-   "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
-   "funding": [
-    {
-     "type": "github",
-     "url": "https://github.com/sponsors/NaturalIntelligence"
-    }
-   ],
-   "license": "MIT",
-   "peer": true,
-   "dependencies": {
-    "path-expression-matcher": "^1.5.0",
-    "xml-naming": "^0.1.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
-   "version": "5.7.3",
-   "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
-   "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
-   "funding": [
-    {
-     "type": "github",
-     "url": "https://github.com/sponsors/NaturalIntelligence"
-    }
-   ],
-   "license": "MIT",
-   "peer": true,
-   "dependencies": {
-    "@nodable/entities": "^2.1.0",
-    "fast-xml-builder": "^1.1.7",
-    "path-expression-matcher": "^1.5.0",
-    "strnum": "^2.2.3"
-   },
-   "bin": {
-    "fxparser": "src/cli/cli.js"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
-   "version": "3.2.0",
-   "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-   "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-   "funding": [
-    {
-     "type": "github",
-     "url": "https://github.com/sponsors/jimmywarting"
-    },
-    {
-     "type": "paypal",
-     "url": "https://paypal.me/jimmywarting"
-    }
-   ],
-   "license": "MIT",
-   "peer": true,
-   "dependencies": {
-    "node-domexception": "^1.0.0",
-    "web-streams-polyfill": "^3.0.3"
-   },
-   "engines": {
-    "node": "^12.20 || >= 14.13"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
-   "version": "4.0.10",
-   "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-   "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-   "license": "MIT",
-   "peer": true,
-   "dependencies": {
-    "fetch-blob": "^3.1.2"
-   },
-   "engines": {
-    "node": ">=12.20.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
-   "version": "7.1.4",
-   "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
-   "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "extend": "^3.0.2",
-    "https-proxy-agent": "^7.0.1",
-    "node-fetch": "^3.3.2"
-   },
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
-   "version": "8.1.2",
-   "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
-   "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "gaxios": "^7.0.0",
-    "google-logging-utils": "^1.0.0",
-    "json-bigint": "^1.0.0"
-   },
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
-   "version": "1.6.0",
-   "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
-   "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-   "license": "MIT",
-   "peer": true,
-   "engines": {
-    "node": ">=18"
-   },
-   "funding": {
-    "url": "https://github.com/sponsors/sindresorhus"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
-   "version": "13.0.6",
-   "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-   "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-   "license": "BlueOak-1.0.0",
-   "peer": true,
-   "dependencies": {
-    "minimatch": "^10.2.2",
-    "minipass": "^7.1.3",
-    "path-scurry": "^2.0.2"
-   },
-   "engines": {
-    "node": "18 || 20 || >=22"
-   },
-   "funding": {
-    "url": "https://github.com/sponsors/isaacs"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
-   "version": "10.6.2",
-   "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
-   "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "dependencies": {
-    "base64-js": "^1.3.0",
-    "ecdsa-sig-formatter": "^1.0.11",
-    "gaxios": "^7.1.4",
-    "gcp-metadata": "8.1.2",
-    "google-logging-utils": "1.1.3",
-    "jws": "^4.0.0"
-   },
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
-   "version": "1.1.3",
-   "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
-   "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "engines": {
-    "node": ">=14"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
-   "version": "4.2.11",
-   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-   "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-   "license": "ISC",
-   "peer": true
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
-   "version": "10.7.3",
-   "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-   "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
-   "license": "BSD-3-Clause",
-   "peer": true,
-   "engines": {
-    "node": "*"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/hosted-git-info": {
-   "version": "9.0.3",
-   "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
-   "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
-   "license": "ISC",
-   "peer": true,
-   "dependencies": {
-    "lru-cache": "^11.1.0"
-   },
-   "engines": {
-    "node": "^20.17.0 || >=22.9.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
-   "version": "7.0.2",
-   "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-   "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-   "license": "MIT",
-   "peer": true,
-   "dependencies": {
-    "agent-base": "^7.1.0",
-    "debug": "^4.3.4"
-   },
-   "engines": {
-    "node": ">= 14"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
-   "version": "7.0.6",
-   "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-   "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-   "license": "MIT",
-   "peer": true,
-   "dependencies": {
-    "agent-base": "^7.1.2",
-    "debug": "4"
-   },
-   "engines": {
-    "node": ">= 14"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
-   "version": "7.0.5",
-   "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-   "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-   "license": "MIT",
-   "peer": true,
-   "engines": {
-    "node": ">= 4"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
-   "version": "2.0.0",
-   "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-   "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-   "license": "ISC",
-   "peer": true
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
-   "version": "2.7.0",
-   "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
-   "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-   "license": "MIT",
-   "peer": true,
-   "bin": {
-    "jiti": "lib/jiti-cli.mjs"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
-   "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-   "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-   "license": "MIT",
-   "peer": true,
-   "dependencies": {
-    "bignumber.js": "^9.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
-   "version": "3.1.1",
-   "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
-   "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-   "license": "MIT",
-   "peer": true,
-   "dependencies": {
-    "@babel/runtime": "^7.18.3",
-    "ts-algebra": "^2.0.0"
-   },
-   "engines": {
-    "node": ">=16"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
-   "version": "2.0.1",
-   "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
-   "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
-   "license": "MIT",
-   "peer": true,
-   "dependencies": {
-    "buffer-equal-constant-time": "^1.0.1",
-    "ecdsa-sig-formatter": "1.0.11",
-    "safe-buffer": "^5.0.1"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
-   "version": "4.0.1",
-   "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
-   "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
-   "license": "MIT",
-   "peer": true,
-   "dependencies": {
-    "jwa": "^2.0.1",
-    "safe-buffer": "^5.0.1"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
-   "version": "5.3.2",
-   "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-   "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-   "license": "Apache-2.0",
-   "peer": true
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
-   "version": "11.4.0",
-   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
-   "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
-   "license": "BlueOak-1.0.0",
-   "peer": true,
-   "engines": {
-    "node": "20 || >=22"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
-   "version": "18.0.5",
-   "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
-   "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
-   "license": "MIT",
-   "peer": true,
-   "bin": {
-    "marked": "bin/marked.js"
-   },
-   "engines": {
-    "node": ">= 20"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
-   "version": "10.2.5",
-   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-   "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-   "license": "BlueOak-1.0.0",
-   "peer": true,
-   "dependencies": {
-    "brace-expansion": "^5.0.5"
-   },
-   "engines": {
-    "node": "18 || 20 || >=22"
-   },
-   "funding": {
-    "url": "https://github.com/sponsors/isaacs"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
-   "version": "7.1.3",
-   "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-   "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-   "license": "BlueOak-1.0.0",
-   "peer": true,
-   "engines": {
-    "node": ">=16 || 14 >=14.17"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
-   "version": "2.1.3",
-   "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-   "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-   "license": "MIT",
-   "peer": true
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
-   "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-   "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-   "deprecated": "Use your platform's native DOMException instead",
-   "funding": [
-    {
-     "type": "github",
-     "url": "https://github.com/sponsors/jimmywarting"
-    },
-    {
-     "type": "github",
-     "url": "https://paypal.me/jimmywarting"
-    }
-   ],
-   "license": "MIT",
-   "peer": true,
-   "engines": {
-    "node": ">=10.5.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
-   "version": "3.3.2",
-   "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-   "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-   "license": "MIT",
-   "peer": true,
-   "dependencies": {
-    "data-uri-to-buffer": "^4.0.0",
-    "fetch-blob": "^3.1.4",
-    "formdata-polyfill": "^4.0.10"
-   },
-   "engines": {
-    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-   },
-   "funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/node-fetch"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
-   "version": "6.26.0",
-   "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-   "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
-   "license": "Apache-2.0",
-   "peer": true,
-   "bin": {
-    "openai": "bin/cli"
-   },
-   "peerDependencies": {
-    "ws": "^8.18.0",
-    "zod": "^3.25 || ^4.0"
-   },
-   "peerDependenciesMeta": {
-    "ws": {
-     "optional": true
-    },
-    "zod": {
-     "optional": true
-    }
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
-   "version": "4.6.2",
-   "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-   "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
-   "license": "MIT",
-   "peer": true,
-   "dependencies": {
-    "@types/retry": "0.12.0",
-    "retry": "^0.13.1"
-   },
-   "engines": {
-    "node": ">=8"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
-   "version": "0.12.0",
-   "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-   "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-   "license": "MIT",
-   "peer": true
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
-   "version": "0.1.7",
-   "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
-   "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
-   "license": "MIT",
-   "peer": true
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
-   "version": "1.5.0",
-   "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-   "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
-   "funding": [
-    {
-     "type": "github",
-     "url": "https://github.com/sponsors/NaturalIntelligence"
-    }
-   ],
-   "license": "MIT",
-   "peer": true,
-   "engines": {
-    "node": ">=14.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
-   "version": "3.1.1",
-   "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-   "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-   "license": "MIT",
-   "peer": true,
-   "engines": {
-    "node": ">=8"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
-   "version": "2.0.2",
-   "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-   "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-   "license": "BlueOak-1.0.0",
-   "peer": true,
-   "dependencies": {
-    "lru-cache": "^11.0.0",
-    "minipass": "^7.1.2"
-   },
-   "engines": {
-    "node": "18 || 20 || >=22"
-   },
-   "funding": {
-    "url": "https://github.com/sponsors/isaacs"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
-   "version": "4.1.2",
-   "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
-   "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-   "license": "MIT",
-   "peer": true,
-   "dependencies": {
-    "graceful-fs": "^4.2.4",
-    "retry": "^0.12.0",
-    "signal-exit": "^3.0.2"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile/node_modules/retry": {
-   "version": "0.12.0",
-   "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-   "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-   "license": "MIT",
-   "peer": true,
-   "engines": {
-    "node": ">= 4"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
-   "version": "7.6.5",
-   "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
-   "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
-   "hasInstallScript": true,
-   "license": "BSD-3-Clause",
-   "peer": true,
-   "dependencies": {
-    "@protobufjs/aspromise": "^1.1.2",
-    "@protobufjs/base64": "^1.1.2",
-    "@protobufjs/codegen": "^2.0.5",
-    "@protobufjs/eventemitter": "^1.1.1",
-    "@protobufjs/fetch": "^1.1.1",
-    "@protobufjs/float": "^1.0.2",
-    "@protobufjs/path": "^1.1.2",
-    "@protobufjs/pool": "^1.1.0",
-    "@protobufjs/utf8": "^1.1.1",
-    "@types/node": ">=13.7.0",
-    "long": "^5.3.2"
-   },
-   "engines": {
-    "node": ">=12.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
-   "version": "0.13.1",
-   "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-   "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-   "license": "MIT",
-   "peer": true,
-   "engines": {
-    "node": ">= 4"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
-   "version": "5.2.1",
-   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-   "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-   "funding": [
-    {
-     "type": "github",
-     "url": "https://github.com/sponsors/feross"
-    },
-    {
-     "type": "patreon",
-     "url": "https://www.patreon.com/feross"
-    },
-    {
-     "type": "consulting",
-     "url": "https://feross.org/support"
-    }
-   ],
-   "license": "MIT",
-   "peer": true
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
-   "version": "7.8.0",
-   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-   "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
-   "license": "ISC",
-   "peer": true,
-   "bin": {
-    "semver": "bin/semver.js"
-   },
-   "engines": {
-    "node": ">=10"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
-   "version": "2.0.0",
-   "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-   "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-   "license": "MIT",
-   "peer": true,
-   "dependencies": {
-    "shebang-regex": "^3.0.0"
-   },
-   "engines": {
-    "node": ">=8"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-regex": {
-   "version": "3.0.0",
-   "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-   "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-   "license": "MIT",
-   "peer": true,
-   "engines": {
-    "node": ">=8"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/signal-exit": {
-   "version": "3.0.7",
-   "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-   "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-   "license": "ISC",
-   "peer": true
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
-   "version": "2.3.0",
-   "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-   "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
-   "funding": [
-    {
-     "type": "github",
-     "url": "https://github.com/sponsors/NaturalIntelligence"
-    }
-   ],
-   "license": "MIT",
-   "peer": true
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
-   "version": "2.0.0",
-   "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
-   "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-   "license": "MIT",
-   "peer": true
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
-   "version": "2.8.1",
-   "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-   "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-   "license": "0BSD",
-   "peer": true
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
-   "version": "1.1.38",
-   "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-   "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
-   "license": "MIT",
-   "peer": true
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
-   "version": "8.5.0",
-   "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
-   "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
-   "license": "MIT",
-   "peer": true,
-   "engines": {
-    "node": ">=22.19.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
-   "version": "6.21.0",
-   "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-   "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-   "license": "MIT",
-   "peer": true
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
-   "version": "3.3.3",
-   "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-   "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-   "license": "MIT",
-   "peer": true,
-   "engines": {
-    "node": ">= 8"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
-   "version": "2.0.2",
-   "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-   "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-   "license": "ISC",
-   "peer": true,
-   "dependencies": {
-    "isexe": "^2.0.0"
-   },
-   "bin": {
-    "node-which": "bin/node-which"
-   },
-   "engines": {
-    "node": ">= 8"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
-   "version": "8.21.0",
-   "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-   "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-   "license": "MIT",
-   "peer": true,
-   "engines": {
-    "node": ">=10.0.0"
-   },
-   "peerDependencies": {
-    "bufferutil": "^4.0.1",
-    "utf-8-validate": ">=5.0.2"
-   },
-   "peerDependenciesMeta": {
-    "bufferutil": {
-     "optional": true
-    },
-    "utf-8-validate": {
-     "optional": true
-    }
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
-   "version": "0.1.0",
-   "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-   "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
-   "funding": [
-    {
-     "type": "github",
-     "url": "https://github.com/sponsors/NaturalIntelligence"
-    }
-   ],
-   "license": "MIT",
-   "peer": true,
-   "engines": {
-    "node": ">=16.0.0"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
-   "version": "2.9.0",
-   "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-   "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-   "license": "ISC",
-   "peer": true,
-   "bin": {
-    "yaml": "bin.mjs"
-   },
-   "engines": {
-    "node": ">= 14.6"
-   },
-   "funding": {
-    "url": "https://github.com/sponsors/eemeli"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
-   "version": "3.25.76",
-   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-   "license": "MIT",
-   "peer": true,
-   "funding": {
-    "url": "https://github.com/sponsors/colinhacks"
-   }
-  },
-  "node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
-   "version": "3.25.2",
-   "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-   "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-   "license": "ISC",
-   "peer": true,
-   "peerDependencies": {
-    "zod": "^3.25.28 || ^4"
-   }
-  },
-  "node_modules/@earendil-works/pi-tui": {
-   "version": "0.82.0",
-   "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.82.0.tgz",
-   "integrity": "sha512-9IDjQOXne7t9l2s2YcjnIBxsVNVPE7qScVSB3YmFlXsBW4pfo2gOElTxggV84KrRiGqABnlFPBWbf0k54hszHQ==",
-   "license": "MIT",
-   "peer": true,
-   "dependencies": {
-    "get-east-asian-width": "1.6.0",
-    "marked": "18.0.5"
-   },
-   "engines": {
-    "node": ">=22.19.0"
-   }
-  },
-  "node_modules/@esbuild/aix-ppc64": {
-   "version": "0.28.1",
-   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
-   "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
-   "cpu": [
-    "ppc64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "aix"
-   ],
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@esbuild/android-arm": {
-   "version": "0.28.1",
-   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
-   "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
-   "cpu": [
-    "arm"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "android"
-   ],
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@esbuild/android-arm64": {
-   "version": "0.28.1",
-   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
-   "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
-   "cpu": [
-    "arm64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "android"
-   ],
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@esbuild/android-x64": {
-   "version": "0.28.1",
-   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
-   "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
-   "cpu": [
-    "x64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "android"
-   ],
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@esbuild/darwin-arm64": {
-   "version": "0.28.1",
-   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
-   "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
-   "cpu": [
-    "arm64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "darwin"
-   ],
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@esbuild/darwin-x64": {
-   "version": "0.28.1",
-   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
-   "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
-   "cpu": [
-    "x64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "darwin"
-   ],
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@esbuild/freebsd-arm64": {
-   "version": "0.28.1",
-   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
-   "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
-   "cpu": [
-    "arm64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "freebsd"
-   ],
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@esbuild/freebsd-x64": {
-   "version": "0.28.1",
-   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
-   "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
-   "cpu": [
-    "x64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "freebsd"
-   ],
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@esbuild/linux-arm": {
-   "version": "0.28.1",
-   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
-   "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
-   "cpu": [
-    "arm"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "linux"
-   ],
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@esbuild/linux-arm64": {
-   "version": "0.28.1",
-   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
-   "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
-   "cpu": [
-    "arm64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "linux"
-   ],
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@esbuild/linux-ia32": {
-   "version": "0.28.1",
-   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
-   "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
-   "cpu": [
-    "ia32"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "linux"
-   ],
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@esbuild/linux-loong64": {
-   "version": "0.28.1",
-   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
-   "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
-   "cpu": [
-    "loong64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "linux"
-   ],
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@esbuild/linux-mips64el": {
-   "version": "0.28.1",
-   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
-   "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
-   "cpu": [
-    "mips64el"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "linux"
-   ],
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@esbuild/linux-ppc64": {
-   "version": "0.28.1",
-   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
-   "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
-   "cpu": [
-    "ppc64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "linux"
-   ],
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@esbuild/linux-riscv64": {
-   "version": "0.28.1",
-   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
-   "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
-   "cpu": [
-    "riscv64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "linux"
-   ],
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@esbuild/linux-s390x": {
-   "version": "0.28.1",
-   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
-   "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
-   "cpu": [
-    "s390x"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "linux"
-   ],
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@esbuild/linux-x64": {
-   "version": "0.28.1",
-   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
-   "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
-   "cpu": [
-    "x64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "linux"
-   ],
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@esbuild/netbsd-arm64": {
-   "version": "0.28.1",
-   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
-   "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
-   "cpu": [
-    "arm64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "netbsd"
-   ],
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@esbuild/netbsd-x64": {
-   "version": "0.28.1",
-   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
-   "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
-   "cpu": [
-    "x64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "netbsd"
-   ],
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@esbuild/openbsd-arm64": {
-   "version": "0.28.1",
-   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
-   "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
-   "cpu": [
-    "arm64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "openbsd"
-   ],
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@esbuild/openbsd-x64": {
-   "version": "0.28.1",
-   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
-   "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
-   "cpu": [
-    "x64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "openbsd"
-   ],
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@esbuild/openharmony-arm64": {
-   "version": "0.28.1",
-   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
-   "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
-   "cpu": [
-    "arm64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "openharmony"
-   ],
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@esbuild/sunos-x64": {
-   "version": "0.28.1",
-   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
-   "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
-   "cpu": [
-    "x64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "sunos"
-   ],
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@esbuild/win32-arm64": {
-   "version": "0.28.1",
-   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
-   "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
-   "cpu": [
-    "arm64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "win32"
-   ],
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@esbuild/win32-ia32": {
-   "version": "0.28.1",
-   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
-   "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
-   "cpu": [
-    "ia32"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "win32"
-   ],
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@esbuild/win32-x64": {
-   "version": "0.28.1",
-   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
-   "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
-   "cpu": [
-    "x64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "win32"
-   ],
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/@google/genai": {
-   "version": "1.52.0",
-   "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
-   "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
-   "hasInstallScript": true,
-   "license": "Apache-2.0",
-   "dependencies": {
-    "google-auth-library": "^10.3.0",
-    "p-retry": "^4.6.2",
-    "protobufjs": "^7.5.4",
-    "ws": "^8.18.0"
-   },
-   "engines": {
-    "node": ">=20.0.0"
-   },
-   "peerDependencies": {
-    "@modelcontextprotocol/sdk": "^1.25.2"
-   },
-   "peerDependenciesMeta": {
-    "@modelcontextprotocol/sdk": {
-     "optional": true
-    }
-   }
-  },
-  "node_modules/@jridgewell/sourcemap-codec": {
-   "version": "1.5.5",
-   "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-   "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-   "dev": true,
-   "license": "MIT"
-  },
-  "node_modules/@mistralai/mistralai": {
-   "version": "2.2.6",
-   "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-   "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@opentelemetry/semantic-conventions": "^1.40.0",
-    "ws": "^8.18.0",
-    "zod": "^3.25.0 || ^4.0.0",
-    "zod-to-json-schema": "^3.25.0"
-   },
-   "peerDependencies": {
-    "@opentelemetry/api": "^1.9.0"
-   },
-   "peerDependenciesMeta": {
-    "@opentelemetry/api": {
-     "optional": true
-    }
-   }
-  },
-  "node_modules/@opentelemetry/api": {
-   "version": "1.9.0",
-   "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-   "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-   "license": "Apache-2.0",
-   "engines": {
-    "node": ">=8.0.0"
-   }
-  },
-  "node_modules/@opentelemetry/semantic-conventions": {
-   "version": "1.43.0",
-   "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
-   "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
-   "license": "Apache-2.0",
-   "engines": {
-    "node": ">=14"
-   }
-  },
-  "node_modules/@protobufjs/aspromise": {
-   "version": "1.1.2",
-   "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-   "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-   "license": "BSD-3-Clause"
-  },
-  "node_modules/@protobufjs/base64": {
-   "version": "1.1.2",
-   "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-   "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-   "license": "BSD-3-Clause"
-  },
-  "node_modules/@protobufjs/codegen": {
-   "version": "2.0.5",
-   "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
-   "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-   "license": "BSD-3-Clause"
-  },
-  "node_modules/@protobufjs/eventemitter": {
-   "version": "1.1.1",
-   "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
-   "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
-   "license": "BSD-3-Clause"
-  },
-  "node_modules/@protobufjs/fetch": {
-   "version": "1.1.1",
-   "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
-   "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
-   "license": "BSD-3-Clause",
-   "dependencies": {
-    "@protobufjs/aspromise": "^1.1.1"
-   }
-  },
-  "node_modules/@protobufjs/float": {
-   "version": "1.0.2",
-   "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-   "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-   "license": "BSD-3-Clause"
-  },
-  "node_modules/@protobufjs/path": {
-   "version": "1.1.2",
-   "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-   "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-   "license": "BSD-3-Clause"
-  },
-  "node_modules/@protobufjs/pool": {
-   "version": "1.1.0",
-   "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-   "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-   "license": "BSD-3-Clause"
-  },
-  "node_modules/@protobufjs/utf8": {
-   "version": "1.1.2",
-   "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
-   "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
-   "license": "BSD-3-Clause"
-  },
-  "node_modules/@rollup/rollup-android-arm-eabi": {
-   "version": "4.62.2",
-   "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
-   "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
-   "cpu": [
-    "arm"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "android"
-   ]
-  },
-  "node_modules/@rollup/rollup-android-arm64": {
-   "version": "4.62.2",
-   "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
-   "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
-   "cpu": [
-    "arm64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "android"
-   ]
-  },
-  "node_modules/@rollup/rollup-darwin-arm64": {
-   "version": "4.62.2",
-   "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
-   "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
-   "cpu": [
-    "arm64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "darwin"
-   ]
-  },
-  "node_modules/@rollup/rollup-darwin-x64": {
-   "version": "4.62.2",
-   "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
-   "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
-   "cpu": [
-    "x64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "darwin"
-   ]
-  },
-  "node_modules/@rollup/rollup-freebsd-arm64": {
-   "version": "4.62.2",
-   "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
-   "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
-   "cpu": [
-    "arm64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "freebsd"
-   ]
-  },
-  "node_modules/@rollup/rollup-freebsd-x64": {
-   "version": "4.62.2",
-   "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
-   "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
-   "cpu": [
-    "x64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "freebsd"
-   ]
-  },
-  "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-   "version": "4.62.2",
-   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
-   "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
-   "cpu": [
-    "arm"
-   ],
-   "dev": true,
-   "libc": [
-    "glibc"
-   ],
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "linux"
-   ]
-  },
-  "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-   "version": "4.62.2",
-   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
-   "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
-   "cpu": [
-    "arm"
-   ],
-   "dev": true,
-   "libc": [
-    "musl"
-   ],
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "linux"
-   ]
-  },
-  "node_modules/@rollup/rollup-linux-arm64-gnu": {
-   "version": "4.62.2",
-   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
-   "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
-   "cpu": [
-    "arm64"
-   ],
-   "dev": true,
-   "libc": [
-    "glibc"
-   ],
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "linux"
-   ]
-  },
-  "node_modules/@rollup/rollup-linux-arm64-musl": {
-   "version": "4.62.2",
-   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
-   "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
-   "cpu": [
-    "arm64"
-   ],
-   "dev": true,
-   "libc": [
-    "musl"
-   ],
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "linux"
-   ]
-  },
-  "node_modules/@rollup/rollup-linux-loong64-gnu": {
-   "version": "4.62.2",
-   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
-   "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
-   "cpu": [
-    "loong64"
-   ],
-   "dev": true,
-   "libc": [
-    "glibc"
-   ],
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "linux"
-   ]
-  },
-  "node_modules/@rollup/rollup-linux-loong64-musl": {
-   "version": "4.62.2",
-   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
-   "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
-   "cpu": [
-    "loong64"
-   ],
-   "dev": true,
-   "libc": [
-    "musl"
-   ],
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "linux"
-   ]
-  },
-  "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-   "version": "4.62.2",
-   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
-   "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
-   "cpu": [
-    "ppc64"
-   ],
-   "dev": true,
-   "libc": [
-    "glibc"
-   ],
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "linux"
-   ]
-  },
-  "node_modules/@rollup/rollup-linux-ppc64-musl": {
-   "version": "4.62.2",
-   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
-   "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
-   "cpu": [
-    "ppc64"
-   ],
-   "dev": true,
-   "libc": [
-    "musl"
-   ],
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "linux"
-   ]
-  },
-  "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-   "version": "4.62.2",
-   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
-   "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
-   "cpu": [
-    "riscv64"
-   ],
-   "dev": true,
-   "libc": [
-    "glibc"
-   ],
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "linux"
-   ]
-  },
-  "node_modules/@rollup/rollup-linux-riscv64-musl": {
-   "version": "4.62.2",
-   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
-   "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
-   "cpu": [
-    "riscv64"
-   ],
-   "dev": true,
-   "libc": [
-    "musl"
-   ],
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "linux"
-   ]
-  },
-  "node_modules/@rollup/rollup-linux-s390x-gnu": {
-   "version": "4.62.2",
-   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
-   "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
-   "cpu": [
-    "s390x"
-   ],
-   "dev": true,
-   "libc": [
-    "glibc"
-   ],
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "linux"
-   ]
-  },
-  "node_modules/@rollup/rollup-linux-x64-gnu": {
-   "version": "4.62.2",
-   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
-   "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
-   "cpu": [
-    "x64"
-   ],
-   "dev": true,
-   "libc": [
-    "glibc"
-   ],
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "linux"
-   ]
-  },
-  "node_modules/@rollup/rollup-linux-x64-musl": {
-   "version": "4.62.2",
-   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
-   "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
-   "cpu": [
-    "x64"
-   ],
-   "dev": true,
-   "libc": [
-    "musl"
-   ],
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "linux"
-   ]
-  },
-  "node_modules/@rollup/rollup-openbsd-x64": {
-   "version": "4.62.2",
-   "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
-   "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
-   "cpu": [
-    "x64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "openbsd"
-   ]
-  },
-  "node_modules/@rollup/rollup-openharmony-arm64": {
-   "version": "4.62.2",
-   "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
-   "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
-   "cpu": [
-    "arm64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "openharmony"
-   ]
-  },
-  "node_modules/@rollup/rollup-win32-arm64-msvc": {
-   "version": "4.62.2",
-   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
-   "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
-   "cpu": [
-    "arm64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "win32"
-   ]
-  },
-  "node_modules/@rollup/rollup-win32-ia32-msvc": {
-   "version": "4.62.2",
-   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
-   "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
-   "cpu": [
-    "ia32"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "win32"
-   ]
-  },
-  "node_modules/@rollup/rollup-win32-x64-gnu": {
-   "version": "4.62.2",
-   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
-   "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
-   "cpu": [
-    "x64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "win32"
-   ]
-  },
-  "node_modules/@rollup/rollup-win32-x64-msvc": {
-   "version": "4.62.2",
-   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
-   "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
-   "cpu": [
-    "x64"
-   ],
-   "dev": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "win32"
-   ]
-  },
-  "node_modules/@smithy/core": {
-   "version": "3.29.3",
-   "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.3.tgz",
-   "integrity": "sha512-L+Ys6ecjk5vwPMAKHBpPKlJ3DkqwNcnfEISXBZIsVvWG/XKXfsAP8mwIYlTeLcd2ElHdesPI8OuOmJSFAPhm6A==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@smithy/types": "^4.16.1",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=18.0.0"
-   }
-  },
-  "node_modules/@smithy/credential-provider-imds": {
-   "version": "4.4.8",
-   "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.8.tgz",
-   "integrity": "sha512-q9J7JTiXrAhB8sDp4px97uEPT7CwKH61Co78grdNQvU8QZAdiuaSRhP0tUVf2ogy36RZTrlMU1rBmDEH+cnkiA==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@smithy/core": "^3.29.3",
-    "@smithy/types": "^4.16.1",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=18.0.0"
-   }
-  },
-  "node_modules/@smithy/fetch-http-handler": {
-   "version": "5.6.5",
-   "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.5.tgz",
-   "integrity": "sha512-SuqeisTyPoiIPtIYru/sGxGyXzmZ+8nnFOhC+qRPglt06Ebd1yH//CDltZB2J/3WBNVhwfUaZ0EtHB3cm2X32g==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@smithy/core": "^3.29.3",
-    "@smithy/types": "^4.16.1",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=18.0.0"
-   }
-  },
-  "node_modules/@smithy/is-array-buffer": {
-   "version": "2.2.0",
-   "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-   "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=14.0.0"
-   }
-  },
-  "node_modules/@smithy/node-http-handler": {
-   "version": "4.7.3",
-   "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
-   "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@smithy/core": "^3.24.3",
-    "@smithy/types": "^4.14.2",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=18.0.0"
-   }
-  },
-  "node_modules/@smithy/signature-v4": {
-   "version": "5.6.4",
-   "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.4.tgz",
-   "integrity": "sha512-B89bpf2t/y/wia6LZ+4JfHXYQT9PnVftsH05rgJKKIStS7r/4XSs9HOjtPoLtgcA6HCW9jVqX5DBbq7E0PAkiQ==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@smithy/core": "^3.29.3",
-    "@smithy/types": "^4.16.1",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=18.0.0"
-   }
-  },
-  "node_modules/@smithy/types": {
-   "version": "4.16.1",
-   "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
-   "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=18.0.0"
-   }
-  },
-  "node_modules/@smithy/util-buffer-from": {
-   "version": "2.2.0",
-   "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-   "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@smithy/is-array-buffer": "^2.2.0",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=14.0.0"
-   }
-  },
-  "node_modules/@smithy/util-utf8": {
-   "version": "2.3.0",
-   "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-   "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "@smithy/util-buffer-from": "^2.2.0",
-    "tslib": "^2.6.2"
-   },
-   "engines": {
-    "node": ">=14.0.0"
-   }
-  },
-  "node_modules/@types/chai": {
-   "version": "5.2.3",
-   "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
-   "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
-   "dev": true,
-   "license": "MIT",
-   "dependencies": {
-    "@types/deep-eql": "*",
-    "assertion-error": "^2.0.1"
-   }
-  },
-  "node_modules/@types/deep-eql": {
-   "version": "4.0.2",
-   "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
-   "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-   "dev": true,
-   "license": "MIT"
-  },
-  "node_modules/@types/estree": {
-   "version": "1.0.9",
-   "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
-   "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-   "dev": true,
-   "license": "MIT"
-  },
-  "node_modules/@types/node": {
-   "version": "22.20.1",
-   "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
-   "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
-   "license": "MIT",
-   "dependencies": {
-    "undici-types": "~6.21.0"
-   }
-  },
-  "node_modules/@types/retry": {
-   "version": "0.12.0",
-   "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-   "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-   "license": "MIT"
-  },
-  "node_modules/@vitest/expect": {
-   "version": "3.2.7",
-   "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
-   "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
-   "dev": true,
-   "license": "MIT",
-   "dependencies": {
-    "@types/chai": "^5.2.2",
-    "@vitest/spy": "3.2.7",
-    "@vitest/utils": "3.2.7",
-    "chai": "^5.2.0",
-    "tinyrainbow": "^2.0.0"
-   },
-   "funding": {
-    "url": "https://opencollective.com/vitest"
-   }
-  },
-  "node_modules/@vitest/mocker": {
-   "version": "3.2.7",
-   "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
-   "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
-   "dev": true,
-   "license": "MIT",
-   "dependencies": {
-    "@vitest/spy": "3.2.7",
-    "estree-walker": "^3.0.3",
-    "magic-string": "^0.30.17"
-   },
-   "funding": {
-    "url": "https://opencollective.com/vitest"
-   },
-   "peerDependencies": {
-    "msw": "^2.4.9",
-    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-   },
-   "peerDependenciesMeta": {
-    "msw": {
-     "optional": true
-    },
-    "vite": {
-     "optional": true
-    }
-   }
-  },
-  "node_modules/@vitest/pretty-format": {
-   "version": "3.2.7",
-   "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
-   "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
-   "dev": true,
-   "license": "MIT",
-   "dependencies": {
-    "tinyrainbow": "^2.0.0"
-   },
-   "funding": {
-    "url": "https://opencollective.com/vitest"
-   }
-  },
-  "node_modules/@vitest/runner": {
-   "version": "3.2.7",
-   "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
-   "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
-   "dev": true,
-   "license": "MIT",
-   "dependencies": {
-    "@vitest/utils": "3.2.7",
-    "pathe": "^2.0.3",
-    "strip-literal": "^3.0.0"
-   },
-   "funding": {
-    "url": "https://opencollective.com/vitest"
-   }
-  },
-  "node_modules/@vitest/snapshot": {
-   "version": "3.2.7",
-   "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
-   "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
-   "dev": true,
-   "license": "MIT",
-   "dependencies": {
-    "@vitest/pretty-format": "3.2.7",
-    "magic-string": "^0.30.17",
-    "pathe": "^2.0.3"
-   },
-   "funding": {
-    "url": "https://opencollective.com/vitest"
-   }
-  },
-  "node_modules/@vitest/spy": {
-   "version": "3.2.7",
-   "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
-   "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
-   "dev": true,
-   "license": "MIT",
-   "dependencies": {
-    "tinyspy": "^4.0.3"
-   },
-   "funding": {
-    "url": "https://opencollective.com/vitest"
-   }
-  },
-  "node_modules/@vitest/utils": {
-   "version": "3.2.7",
-   "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
-   "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
-   "dev": true,
-   "license": "MIT",
-   "dependencies": {
-    "@vitest/pretty-format": "3.2.7",
-    "loupe": "^3.1.4",
-    "tinyrainbow": "^2.0.0"
-   },
-   "funding": {
-    "url": "https://opencollective.com/vitest"
-   }
-  },
-  "node_modules/agent-base": {
-   "version": "7.1.4",
-   "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-   "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-   "license": "MIT",
-   "engines": {
-    "node": ">= 14"
-   }
-  },
-  "node_modules/assertion-error": {
-   "version": "2.0.1",
-   "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-   "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-   "dev": true,
-   "license": "MIT",
-   "engines": {
-    "node": ">=12"
-   }
-  },
-  "node_modules/base64-js": {
-   "version": "1.5.1",
-   "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-   "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-   "funding": [
-    {
-     "type": "github",
-     "url": "https://github.com/sponsors/feross"
-    },
-    {
-     "type": "patreon",
-     "url": "https://www.patreon.com/feross"
-    },
-    {
-     "type": "consulting",
-     "url": "https://feross.org/support"
-    }
-   ],
-   "license": "MIT"
-  },
-  "node_modules/bignumber.js": {
-   "version": "9.3.1",
-   "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-   "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
-   "license": "MIT",
-   "engines": {
-    "node": "*"
-   }
-  },
-  "node_modules/bowser": {
-   "version": "2.14.1",
-   "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
-   "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
-   "license": "MIT"
-  },
-  "node_modules/buffer-equal-constant-time": {
-   "version": "1.0.1",
-   "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-   "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-   "license": "BSD-3-Clause"
-  },
-  "node_modules/cac": {
-   "version": "6.7.14",
-   "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-   "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-   "dev": true,
-   "license": "MIT",
-   "engines": {
-    "node": ">=8"
-   }
-  },
-  "node_modules/chai": {
-   "version": "5.3.3",
-   "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-   "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
-   "dev": true,
-   "license": "MIT",
-   "dependencies": {
-    "assertion-error": "^2.0.1",
-    "check-error": "^2.1.1",
-    "deep-eql": "^5.0.1",
-    "loupe": "^3.1.0",
-    "pathval": "^2.0.0"
-   },
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/check-error": {
-   "version": "2.1.3",
-   "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-   "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
-   "dev": true,
-   "license": "MIT",
-   "engines": {
-    "node": ">= 16"
-   }
-  },
-  "node_modules/data-uri-to-buffer": {
-   "version": "4.0.1",
-   "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-   "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-   "license": "MIT",
-   "engines": {
-    "node": ">= 12"
-   }
-  },
-  "node_modules/debug": {
-   "version": "4.4.3",
-   "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-   "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-   "license": "MIT",
-   "dependencies": {
-    "ms": "^2.1.3"
-   },
-   "engines": {
-    "node": ">=6.0"
-   },
-   "peerDependenciesMeta": {
-    "supports-color": {
-     "optional": true
-    }
-   }
-  },
-  "node_modules/deep-eql": {
-   "version": "5.0.2",
-   "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-   "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-   "dev": true,
-   "license": "MIT",
-   "engines": {
-    "node": ">=6"
-   }
-  },
-  "node_modules/diff": {
-   "version": "8.0.4",
-   "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-   "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-   "dev": true,
-   "license": "BSD-3-Clause",
-   "engines": {
-    "node": ">=0.3.1"
-   }
-  },
-  "node_modules/ecdsa-sig-formatter": {
-   "version": "1.0.11",
-   "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-   "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "safe-buffer": "^5.0.1"
-   }
-  },
-  "node_modules/es-module-lexer": {
-   "version": "1.7.0",
-   "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-   "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
-   "dev": true,
-   "license": "MIT"
-  },
-  "node_modules/esbuild": {
-   "version": "0.28.1",
-   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
-   "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-   "dev": true,
-   "hasInstallScript": true,
-   "license": "MIT",
-   "bin": {
-    "esbuild": "bin/esbuild"
-   },
-   "engines": {
-    "node": ">=18"
-   },
-   "optionalDependencies": {
-    "@esbuild/aix-ppc64": "0.28.1",
-    "@esbuild/android-arm": "0.28.1",
-    "@esbuild/android-arm64": "0.28.1",
-    "@esbuild/android-x64": "0.28.1",
-    "@esbuild/darwin-arm64": "0.28.1",
-    "@esbuild/darwin-x64": "0.28.1",
-    "@esbuild/freebsd-arm64": "0.28.1",
-    "@esbuild/freebsd-x64": "0.28.1",
-    "@esbuild/linux-arm": "0.28.1",
-    "@esbuild/linux-arm64": "0.28.1",
-    "@esbuild/linux-ia32": "0.28.1",
-    "@esbuild/linux-loong64": "0.28.1",
-    "@esbuild/linux-mips64el": "0.28.1",
-    "@esbuild/linux-ppc64": "0.28.1",
-    "@esbuild/linux-riscv64": "0.28.1",
-    "@esbuild/linux-s390x": "0.28.1",
-    "@esbuild/linux-x64": "0.28.1",
-    "@esbuild/netbsd-arm64": "0.28.1",
-    "@esbuild/netbsd-x64": "0.28.1",
-    "@esbuild/openbsd-arm64": "0.28.1",
-    "@esbuild/openbsd-x64": "0.28.1",
-    "@esbuild/openharmony-arm64": "0.28.1",
-    "@esbuild/sunos-x64": "0.28.1",
-    "@esbuild/win32-arm64": "0.28.1",
-    "@esbuild/win32-ia32": "0.28.1",
-    "@esbuild/win32-x64": "0.28.1"
-   }
-  },
-  "node_modules/estree-walker": {
-   "version": "3.0.3",
-   "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-   "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-   "dev": true,
-   "license": "MIT",
-   "dependencies": {
-    "@types/estree": "^1.0.0"
-   }
-  },
-  "node_modules/expect-type": {
-   "version": "1.4.0",
-   "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
-   "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
-   "dev": true,
-   "license": "Apache-2.0",
-   "engines": {
-    "node": ">=12.0.0"
-   }
-  },
-  "node_modules/extend": {
-   "version": "3.0.2",
-   "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-   "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-   "license": "MIT"
-  },
-  "node_modules/fdir": {
-   "version": "6.5.0",
-   "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-   "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-   "dev": true,
-   "license": "MIT",
-   "engines": {
-    "node": ">=12.0.0"
-   },
-   "peerDependencies": {
-    "picomatch": "^3 || ^4"
-   },
-   "peerDependenciesMeta": {
-    "picomatch": {
-     "optional": true
-    }
-   }
-  },
-  "node_modules/fetch-blob": {
-   "version": "3.2.0",
-   "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-   "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-   "funding": [
-    {
-     "type": "github",
-     "url": "https://github.com/sponsors/jimmywarting"
-    },
-    {
-     "type": "paypal",
-     "url": "https://paypal.me/jimmywarting"
-    }
-   ],
-   "license": "MIT",
-   "dependencies": {
-    "node-domexception": "^1.0.0",
-    "web-streams-polyfill": "^3.0.3"
-   },
-   "engines": {
-    "node": "^12.20 || >= 14.13"
-   }
-  },
-  "node_modules/formdata-polyfill": {
-   "version": "4.0.10",
-   "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-   "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-   "license": "MIT",
-   "dependencies": {
-    "fetch-blob": "^3.1.2"
-   },
-   "engines": {
-    "node": ">=12.20.0"
-   }
-  },
-  "node_modules/fsevents": {
-   "version": "2.3.3",
-   "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-   "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-   "dev": true,
-   "hasInstallScript": true,
-   "license": "MIT",
-   "optional": true,
-   "os": [
-    "darwin"
-   ],
-   "engines": {
-    "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-   }
-  },
-  "node_modules/gaxios": {
-   "version": "7.2.0",
-   "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.2.0.tgz",
-   "integrity": "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "extend": "^3.0.2",
-    "https-proxy-agent": "^7.0.1",
-    "node-fetch": "^3.3.2"
-   },
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/gcp-metadata": {
-   "version": "8.1.2",
-   "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
-   "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "gaxios": "^7.0.0",
-    "google-logging-utils": "^1.0.0",
-    "json-bigint": "^1.0.0"
-   },
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/get-east-asian-width": {
-   "version": "1.6.0",
-   "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
-   "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-   "license": "MIT",
-   "peer": true,
-   "engines": {
-    "node": ">=18"
-   },
-   "funding": {
-    "url": "https://github.com/sponsors/sindresorhus"
-   }
-  },
-  "node_modules/google-auth-library": {
-   "version": "10.9.0",
-   "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
-   "integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
-   "license": "Apache-2.0",
-   "dependencies": {
-    "base64-js": "^1.3.0",
-    "ecdsa-sig-formatter": "^1.0.11",
-    "gaxios": "^7.1.4",
-    "gcp-metadata": "8.1.2",
-    "google-logging-utils": "1.1.3",
-    "jws": "^4.0.0"
-   },
-   "engines": {
-    "node": ">=18"
-   }
-  },
-  "node_modules/google-logging-utils": {
-   "version": "1.1.3",
-   "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
-   "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
-   "license": "Apache-2.0",
-   "engines": {
-    "node": ">=14"
-   }
-  },
-  "node_modules/http-proxy-agent": {
-   "version": "7.0.2",
-   "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-   "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-   "license": "MIT",
-   "dependencies": {
-    "agent-base": "^7.1.0",
-    "debug": "^4.3.4"
-   },
-   "engines": {
-    "node": ">= 14"
-   }
-  },
-  "node_modules/https-proxy-agent": {
-   "version": "7.0.6",
-   "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-   "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-   "license": "MIT",
-   "dependencies": {
-    "agent-base": "^7.1.2",
-    "debug": "4"
-   },
-   "engines": {
-    "node": ">= 14"
-   }
-  },
-  "node_modules/ignore": {
-   "version": "7.0.5",
-   "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-   "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-   "dev": true,
-   "license": "MIT",
-   "engines": {
-    "node": ">= 4"
-   }
-  },
-  "node_modules/js-tokens": {
-   "version": "9.0.1",
-   "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-   "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-   "dev": true,
-   "license": "MIT"
-  },
-  "node_modules/json-bigint": {
-   "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-   "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-   "license": "MIT",
-   "dependencies": {
-    "bignumber.js": "^9.0.0"
-   }
-  },
-  "node_modules/json-schema-to-ts": {
-   "version": "3.1.1",
-   "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
-   "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-   "license": "MIT",
-   "dependencies": {
-    "@babel/runtime": "^7.18.3",
-    "ts-algebra": "^2.0.0"
-   },
-   "engines": {
-    "node": ">=16"
-   }
-  },
-  "node_modules/jwa": {
-   "version": "2.0.1",
-   "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
-   "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
-   "license": "MIT",
-   "dependencies": {
-    "buffer-equal-constant-time": "^1.0.1",
-    "ecdsa-sig-formatter": "1.0.11",
-    "safe-buffer": "^5.0.1"
-   }
-  },
-  "node_modules/jws": {
-   "version": "4.0.1",
-   "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
-   "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
-   "license": "MIT",
-   "dependencies": {
-    "jwa": "^2.0.1",
-    "safe-buffer": "^5.0.1"
-   }
-  },
-  "node_modules/long": {
-   "version": "5.3.2",
-   "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-   "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-   "license": "Apache-2.0"
-  },
-  "node_modules/loupe": {
-   "version": "3.2.1",
-   "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-   "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-   "dev": true,
-   "license": "MIT"
-  },
-  "node_modules/magic-string": {
-   "version": "0.30.21",
-   "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-   "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-   "dev": true,
-   "license": "MIT",
-   "dependencies": {
-    "@jridgewell/sourcemap-codec": "^1.5.5"
-   }
-  },
-  "node_modules/marked": {
-   "version": "18.0.5",
-   "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
-   "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
-   "license": "MIT",
-   "peer": true,
-   "bin": {
-    "marked": "bin/marked.js"
-   },
-   "engines": {
-    "node": ">= 20"
-   }
-  },
-  "node_modules/ms": {
-   "version": "2.1.3",
-   "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-   "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-   "license": "MIT"
-  },
-  "node_modules/nanoid": {
-   "version": "3.3.16",
-   "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-   "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
-   "dev": true,
-   "funding": [
-    {
-     "type": "github",
-     "url": "https://github.com/sponsors/ai"
-    }
-   ],
-   "license": "MIT",
-   "bin": {
-    "nanoid": "bin/nanoid.cjs"
-   },
-   "engines": {
-    "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-   }
-  },
-  "node_modules/node-domexception": {
-   "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-   "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-   "deprecated": "Use your platform's native DOMException instead",
-   "funding": [
-    {
-     "type": "github",
-     "url": "https://github.com/sponsors/jimmywarting"
-    },
-    {
-     "type": "github",
-     "url": "https://paypal.me/jimmywarting"
-    }
-   ],
-   "license": "MIT",
-   "engines": {
-    "node": ">=10.5.0"
-   }
-  },
-  "node_modules/node-fetch": {
-   "version": "3.3.2",
-   "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-   "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-   "license": "MIT",
-   "dependencies": {
-    "data-uri-to-buffer": "^4.0.0",
-    "fetch-blob": "^3.1.4",
-    "formdata-polyfill": "^4.0.10"
-   },
-   "engines": {
-    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-   },
-   "funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/node-fetch"
-   }
-  },
-  "node_modules/openai": {
-   "version": "6.26.0",
-   "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-   "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
-   "license": "Apache-2.0",
-   "bin": {
-    "openai": "bin/cli"
-   },
-   "peerDependencies": {
-    "ws": "^8.18.0",
-    "zod": "^3.25 || ^4.0"
-   },
-   "peerDependenciesMeta": {
-    "ws": {
-     "optional": true
-    },
-    "zod": {
-     "optional": true
-    }
-   }
-  },
-  "node_modules/p-retry": {
-   "version": "4.6.2",
-   "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-   "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
-   "license": "MIT",
-   "dependencies": {
-    "@types/retry": "0.12.0",
-    "retry": "^0.13.1"
-   },
-   "engines": {
-    "node": ">=8"
-   }
-  },
-  "node_modules/partial-json": {
-   "version": "0.1.7",
-   "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
-   "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
-   "license": "MIT"
-  },
-  "node_modules/pathe": {
-   "version": "2.0.3",
-   "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-   "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-   "dev": true,
-   "license": "MIT"
-  },
-  "node_modules/pathval": {
-   "version": "2.0.1",
-   "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-   "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-   "dev": true,
-   "license": "MIT",
-   "engines": {
-    "node": ">= 14.16"
-   }
-  },
-  "node_modules/picocolors": {
-   "version": "1.1.1",
-   "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-   "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-   "dev": true,
-   "license": "ISC"
-  },
-  "node_modules/picomatch": {
-   "version": "4.0.5",
-   "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-   "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-   "dev": true,
-   "license": "MIT",
-   "engines": {
-    "node": ">=12"
-   },
-   "funding": {
-    "url": "https://github.com/sponsors/jonschlinkert"
-   }
-  },
-  "node_modules/postcss": {
-   "version": "8.5.18",
-   "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-   "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
-   "dev": true,
-   "funding": [
-    {
-     "type": "opencollective",
-     "url": "https://opencollective.com/postcss/"
-    },
-    {
-     "type": "tidelift",
-     "url": "https://tidelift.com/funding/github/npm/postcss"
-    },
-    {
-     "type": "github",
-     "url": "https://github.com/sponsors/ai"
-    }
-   ],
-   "license": "MIT",
-   "dependencies": {
-    "nanoid": "^3.3.12",
-    "picocolors": "^1.1.1",
-    "source-map-js": "^1.2.1"
-   },
-   "engines": {
-    "node": "^10 || ^12 || >=14"
-   }
-  },
-  "node_modules/protobufjs": {
-   "version": "7.6.5",
-   "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
-   "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
-   "hasInstallScript": true,
-   "license": "BSD-3-Clause",
-   "dependencies": {
-    "@protobufjs/aspromise": "^1.1.2",
-    "@protobufjs/base64": "^1.1.2",
-    "@protobufjs/codegen": "^2.0.5",
-    "@protobufjs/eventemitter": "^1.1.1",
-    "@protobufjs/fetch": "^1.1.1",
-    "@protobufjs/float": "^1.0.2",
-    "@protobufjs/path": "^1.1.2",
-    "@protobufjs/pool": "^1.1.0",
-    "@protobufjs/utf8": "^1.1.1",
-    "@types/node": ">=13.7.0",
-    "long": "^5.3.2"
-   },
-   "engines": {
-    "node": ">=12.0.0"
-   }
-  },
-  "node_modules/retry": {
-   "version": "0.13.1",
-   "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-   "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-   "license": "MIT",
-   "engines": {
-    "node": ">= 4"
-   }
-  },
-  "node_modules/rollup": {
-   "version": "4.62.2",
-   "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
-   "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
-   "dev": true,
-   "license": "MIT",
-   "dependencies": {
-    "@types/estree": "1.0.9"
-   },
-   "bin": {
-    "rollup": "dist/bin/rollup"
-   },
-   "engines": {
-    "node": ">=18.0.0",
-    "npm": ">=8.0.0"
-   },
-   "optionalDependencies": {
-    "@rollup/rollup-android-arm-eabi": "4.62.2",
-    "@rollup/rollup-android-arm64": "4.62.2",
-    "@rollup/rollup-darwin-arm64": "4.62.2",
-    "@rollup/rollup-darwin-x64": "4.62.2",
-    "@rollup/rollup-freebsd-arm64": "4.62.2",
-    "@rollup/rollup-freebsd-x64": "4.62.2",
-    "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
-    "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
-    "@rollup/rollup-linux-arm64-gnu": "4.62.2",
-    "@rollup/rollup-linux-arm64-musl": "4.62.2",
-    "@rollup/rollup-linux-loong64-gnu": "4.62.2",
-    "@rollup/rollup-linux-loong64-musl": "4.62.2",
-    "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
-    "@rollup/rollup-linux-ppc64-musl": "4.62.2",
-    "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
-    "@rollup/rollup-linux-riscv64-musl": "4.62.2",
-    "@rollup/rollup-linux-s390x-gnu": "4.62.2",
-    "@rollup/rollup-linux-x64-gnu": "4.62.2",
-    "@rollup/rollup-linux-x64-musl": "4.62.2",
-    "@rollup/rollup-openbsd-x64": "4.62.2",
-    "@rollup/rollup-openharmony-arm64": "4.62.2",
-    "@rollup/rollup-win32-arm64-msvc": "4.62.2",
-    "@rollup/rollup-win32-ia32-msvc": "4.62.2",
-    "@rollup/rollup-win32-x64-gnu": "4.62.2",
-    "@rollup/rollup-win32-x64-msvc": "4.62.2",
-    "fsevents": "~2.3.2"
-   }
-  },
-  "node_modules/safe-buffer": {
-   "version": "5.2.1",
-   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-   "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-   "funding": [
-    {
-     "type": "github",
-     "url": "https://github.com/sponsors/feross"
-    },
-    {
-     "type": "patreon",
-     "url": "https://www.patreon.com/feross"
-    },
-    {
-     "type": "consulting",
-     "url": "https://feross.org/support"
-    }
-   ],
-   "license": "MIT"
-  },
-  "node_modules/siginfo": {
-   "version": "2.0.0",
-   "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
-   "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-   "dev": true,
-   "license": "ISC"
-  },
-  "node_modules/source-map-js": {
-   "version": "1.2.1",
-   "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-   "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-   "dev": true,
-   "license": "BSD-3-Clause",
-   "engines": {
-    "node": ">=0.10.0"
-   }
-  },
-  "node_modules/stackback": {
-   "version": "0.0.2",
-   "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
-   "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-   "dev": true,
-   "license": "MIT"
-  },
-  "node_modules/std-env": {
-   "version": "3.10.0",
-   "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-   "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-   "dev": true,
-   "license": "MIT"
-  },
-  "node_modules/strip-literal": {
-   "version": "3.1.0",
-   "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-   "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
-   "dev": true,
-   "license": "MIT",
-   "dependencies": {
-    "js-tokens": "^9.0.1"
-   },
-   "funding": {
-    "url": "https://github.com/sponsors/antfu"
-   }
-  },
-  "node_modules/tinybench": {
-   "version": "2.9.0",
-   "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
-   "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
-   "dev": true,
-   "license": "MIT"
-  },
-  "node_modules/tinyexec": {
-   "version": "0.3.2",
-   "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-   "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
-   "dev": true,
-   "license": "MIT"
-  },
-  "node_modules/tinyglobby": {
-   "version": "0.2.17",
-   "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-   "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-   "dev": true,
-   "license": "MIT",
-   "dependencies": {
-    "fdir": "^6.5.0",
-    "picomatch": "^4.0.4"
-   },
-   "engines": {
-    "node": ">=12.0.0"
-   },
-   "funding": {
-    "url": "https://github.com/sponsors/SuperchupuDev"
-   }
-  },
-  "node_modules/tinypool": {
-   "version": "1.1.1",
-   "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-   "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-   "dev": true,
-   "license": "MIT",
-   "engines": {
-    "node": "^18.0.0 || >=20.0.0"
-   }
-  },
-  "node_modules/tinyrainbow": {
-   "version": "2.0.0",
-   "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-   "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
-   "dev": true,
-   "license": "MIT",
-   "engines": {
-    "node": ">=14.0.0"
-   }
-  },
-  "node_modules/tinyspy": {
-   "version": "4.0.4",
-   "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
-   "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
-   "dev": true,
-   "license": "MIT",
-   "engines": {
-    "node": ">=14.0.0"
-   }
-  },
-  "node_modules/ts-algebra": {
-   "version": "2.0.0",
-   "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
-   "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-   "license": "MIT"
-  },
-  "node_modules/tslib": {
-   "version": "2.8.1",
-   "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-   "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-   "license": "0BSD"
-  },
-  "node_modules/typebox": {
-   "version": "1.1.38",
-   "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-   "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
-   "license": "MIT"
-  },
-  "node_modules/typescript": {
-   "version": "5.9.3",
-   "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-   "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-   "dev": true,
-   "license": "Apache-2.0",
-   "bin": {
-    "tsc": "bin/tsc",
-    "tsserver": "bin/tsserver"
-   },
-   "engines": {
-    "node": ">=14.17"
-   }
-  },
-  "node_modules/undici-types": {
-   "version": "6.21.0",
-   "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-   "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-   "license": "MIT"
-  },
-  "node_modules/vite": {
-   "version": "7.3.6",
-   "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
-   "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
-   "dev": true,
-   "license": "MIT",
-   "dependencies": {
-    "esbuild": "^0.27.0 || ^0.28.0",
-    "fdir": "^6.5.0",
-    "picomatch": "^4.0.3",
-    "postcss": "^8.5.6",
-    "rollup": "^4.43.0",
-    "tinyglobby": "^0.2.15"
-   },
-   "bin": {
-    "vite": "bin/vite.js"
-   },
-   "engines": {
-    "node": "^20.19.0 || >=22.12.0"
-   },
-   "funding": {
-    "url": "https://github.com/vitejs/vite?sponsor=1"
-   },
-   "optionalDependencies": {
-    "fsevents": "~2.3.3"
-   },
-   "peerDependencies": {
-    "@types/node": "^20.19.0 || >=22.12.0",
-    "jiti": ">=1.21.0",
-    "less": "^4.0.0",
-    "lightningcss": "^1.21.0",
-    "sass": "^1.70.0",
-    "sass-embedded": "^1.70.0",
-    "stylus": ">=0.54.8",
-    "sugarss": "^5.0.0",
-    "terser": "^5.16.0",
-    "tsx": "^4.8.1",
-    "yaml": "^2.4.2"
-   },
-   "peerDependenciesMeta": {
-    "@types/node": {
-     "optional": true
-    },
-    "jiti": {
-     "optional": true
-    },
-    "less": {
-     "optional": true
-    },
-    "lightningcss": {
-     "optional": true
-    },
-    "sass": {
-     "optional": true
-    },
-    "sass-embedded": {
-     "optional": true
-    },
-    "stylus": {
-     "optional": true
-    },
-    "sugarss": {
-     "optional": true
-    },
-    "terser": {
-     "optional": true
-    },
-    "tsx": {
-     "optional": true
-    },
-    "yaml": {
-     "optional": true
-    }
-   }
-  },
-  "node_modules/vite-node": {
-   "version": "3.2.4",
-   "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-   "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-   "dev": true,
-   "license": "MIT",
-   "dependencies": {
-    "cac": "^6.7.14",
-    "debug": "^4.4.1",
-    "es-module-lexer": "^1.7.0",
-    "pathe": "^2.0.3",
-    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-   },
-   "bin": {
-    "vite-node": "vite-node.mjs"
-   },
-   "engines": {
-    "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-   },
-   "funding": {
-    "url": "https://opencollective.com/vitest"
-   }
-  },
-  "node_modules/vitest": {
-   "version": "3.2.7",
-   "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
-   "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
-   "dev": true,
-   "license": "MIT",
-   "dependencies": {
-    "@types/chai": "^5.2.2",
-    "@vitest/expect": "3.2.7",
-    "@vitest/mocker": "3.2.7",
-    "@vitest/pretty-format": "^3.2.7",
-    "@vitest/runner": "3.2.7",
-    "@vitest/snapshot": "3.2.7",
-    "@vitest/spy": "3.2.7",
-    "@vitest/utils": "3.2.7",
-    "chai": "^5.2.0",
-    "debug": "^4.4.1",
-    "expect-type": "^1.2.1",
-    "magic-string": "^0.30.17",
-    "pathe": "^2.0.3",
-    "picomatch": "^4.0.2",
-    "std-env": "^3.9.0",
-    "tinybench": "^2.9.0",
-    "tinyexec": "^0.3.2",
-    "tinyglobby": "^0.2.14",
-    "tinypool": "^1.1.1",
-    "tinyrainbow": "^2.0.0",
-    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-    "vite-node": "3.2.4",
-    "why-is-node-running": "^2.3.0"
-   },
-   "bin": {
-    "vitest": "vitest.mjs"
-   },
-   "engines": {
-    "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-   },
-   "funding": {
-    "url": "https://opencollective.com/vitest"
-   },
-   "peerDependencies": {
-    "@edge-runtime/vm": "*",
-    "@types/debug": "^4.1.12",
-    "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-    "@vitest/browser": "3.2.7",
-    "@vitest/ui": "3.2.7",
-    "happy-dom": "*",
-    "jsdom": "*"
-   },
-   "peerDependenciesMeta": {
-    "@edge-runtime/vm": {
-     "optional": true
-    },
-    "@types/debug": {
-     "optional": true
-    },
-    "@types/node": {
-     "optional": true
-    },
-    "@vitest/browser": {
-     "optional": true
-    },
-    "@vitest/ui": {
-     "optional": true
-    },
-    "happy-dom": {
-     "optional": true
-    },
-    "jsdom": {
-     "optional": true
-    }
-   }
-  },
-  "node_modules/web-streams-polyfill": {
-   "version": "3.3.3",
-   "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-   "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-   "license": "MIT",
-   "engines": {
-    "node": ">= 8"
-   }
-  },
-  "node_modules/why-is-node-running": {
-   "version": "2.3.0",
-   "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
-   "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
-   "dev": true,
-   "license": "MIT",
-   "dependencies": {
-    "siginfo": "^2.0.0",
-    "stackback": "0.0.2"
-   },
-   "bin": {
-    "why-is-node-running": "cli.js"
-   },
-   "engines": {
-    "node": ">=8"
-   }
-  },
-  "node_modules/ws": {
-   "version": "8.21.0",
-   "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-   "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-   "license": "MIT",
-   "engines": {
-    "node": ">=10.0.0"
-   },
-   "peerDependencies": {
-    "bufferutil": "^4.0.1",
-    "utf-8-validate": ">=5.0.2"
-   },
-   "peerDependenciesMeta": {
-    "bufferutil": {
-     "optional": true
-    },
-    "utf-8-validate": {
-     "optional": true
-    }
-   }
-  },
-  "node_modules/yaml": {
-   "version": "2.9.0",
-   "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-   "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-   "dev": true,
-   "license": "ISC",
-   "bin": {
-    "yaml": "bin.mjs"
-   },
-   "engines": {
-    "node": ">= 14.6"
-   },
-   "funding": {
-    "url": "https://github.com/sponsors/eemeli"
-   }
-  },
-  "node_modules/zod": {
-   "version": "4.4.3",
-   "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-   "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-   "license": "MIT",
-   "funding": {
-    "url": "https://github.com/sponsors/colinhacks"
-   }
-  },
-  "node_modules/zod-to-json-schema": {
-   "version": "3.25.2",
-   "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-   "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-   "license": "ISC",
-   "peerDependencies": {
-    "zod": "^3.25.28 || ^4"
-   }
-  }
- }
+	"name": "pi-hydra",
+	"version": "0.1.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "pi-hydra",
+			"version": "0.1.0",
+			"license": "MIT",
+			"devDependencies": {
+				"@earendil-works/pi-agent-core": "^0.84.0",
+				"@earendil-works/pi-ai": "^0.84.0",
+				"@earendil-works/pi-coding-agent": "^0.84.0",
+				"@earendil-works/pi-tui": "^0.84.0",
+				"@types/node": "^22",
+				"typescript": "^5.7",
+				"vitest": "^3"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-agent-core": "*",
+				"@earendil-works/pi-ai": "*",
+				"@earendil-works/pi-coding-agent": "*",
+				"@earendil-works/pi-tui": "*"
+			}
+		},
+		"node_modules/@anthropic-ai/sdk": {
+			"version": "0.91.1",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+			"integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-js": "^5.2.0",
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-js": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/util": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/client-bedrock-runtime": {
+			"version": "3.1048.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+			"integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/credential-provider-node": "^3.972.42",
+				"@aws-sdk/eventstream-handler-node": "^3.972.16",
+				"@aws-sdk/middleware-eventstream": "^3.972.12",
+				"@aws-sdk/middleware-websocket": "^3.972.19",
+				"@aws-sdk/token-providers": "3.1048.0",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/core": {
+			"version": "3.975.1",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.1.tgz",
+			"integrity": "sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.974.0",
+				"@aws-sdk/xml-builder": "^3.972.34",
+				"@aws/lambda-invoke-store": "^0.3.0",
+				"@smithy/core": "^3.29.2",
+				"@smithy/signature-v4": "^5.6.3",
+				"@smithy/types": "^4.16.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.972.57",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.57.tgz",
+			"integrity": "sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.975.1",
+				"@aws-sdk/types": "^3.974.0",
+				"@smithy/core": "^3.29.2",
+				"@smithy/types": "^4.16.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.972.59",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.59.tgz",
+			"integrity": "sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.975.1",
+				"@aws-sdk/types": "^3.974.0",
+				"@smithy/core": "^3.29.2",
+				"@smithy/fetch-http-handler": "^5.6.4",
+				"@smithy/node-http-handler": "^4.9.4",
+				"@smithy/types": "^4.16.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.5.tgz",
+			"integrity": "sha512-bNqdxTQTxmLbomSmlkZFz8L6B/feQ2HHzw4L2zY7Ecp2XffYAZq2uzdWDdxJHJFbEvqd+SRuluJso0P8+xPdbw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.29.3",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.973.1",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.1.tgz",
+			"integrity": "sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.975.1",
+				"@aws-sdk/credential-provider-env": "^3.972.57",
+				"@aws-sdk/credential-provider-http": "^3.972.59",
+				"@aws-sdk/credential-provider-login": "^3.972.63",
+				"@aws-sdk/credential-provider-process": "^3.972.57",
+				"@aws-sdk/credential-provider-sso": "^3.973.1",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.63",
+				"@aws-sdk/nested-clients": "^3.997.31",
+				"@aws-sdk/types": "^3.974.0",
+				"@smithy/core": "^3.29.2",
+				"@smithy/credential-provider-imds": "^4.4.7",
+				"@smithy/types": "^4.16.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-login": {
+			"version": "3.972.63",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.63.tgz",
+			"integrity": "sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.975.1",
+				"@aws-sdk/nested-clients": "^3.997.31",
+				"@aws-sdk/types": "^3.974.0",
+				"@smithy/core": "^3.29.2",
+				"@smithy/types": "^4.16.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.972.66",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.66.tgz",
+			"integrity": "sha512-f+qjRXZpz7sgzbc4QB+6nLKfyKFgRRXzWdXbsKPv/VhVRyHsDyq4yBWC/B75BAJpFIcUeI2XR/3gdWJ677zB4A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "^3.972.57",
+				"@aws-sdk/credential-provider-http": "^3.972.59",
+				"@aws-sdk/credential-provider-ini": "^3.973.1",
+				"@aws-sdk/credential-provider-process": "^3.972.57",
+				"@aws-sdk/credential-provider-sso": "^3.973.1",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.63",
+				"@aws-sdk/types": "^3.974.0",
+				"@smithy/core": "^3.29.2",
+				"@smithy/credential-provider-imds": "^4.4.7",
+				"@smithy/types": "^4.16.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.972.57",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.57.tgz",
+			"integrity": "sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.975.1",
+				"@aws-sdk/types": "^3.974.0",
+				"@smithy/core": "^3.29.2",
+				"@smithy/types": "^4.16.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.973.1",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.1.tgz",
+			"integrity": "sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.975.1",
+				"@aws-sdk/nested-clients": "^3.997.31",
+				"@aws-sdk/token-providers": "3.1083.0",
+				"@aws-sdk/types": "^3.974.0",
+				"@smithy/core": "^3.29.2",
+				"@smithy/types": "^4.16.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+			"version": "3.1083.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1083.0.tgz",
+			"integrity": "sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.975.1",
+				"@aws-sdk/nested-clients": "^3.997.31",
+				"@aws-sdk/types": "^3.974.0",
+				"@smithy/core": "^3.29.2",
+				"@smithy/types": "^4.16.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.972.63",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.63.tgz",
+			"integrity": "sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.975.1",
+				"@aws-sdk/nested-clients": "^3.997.31",
+				"@aws-sdk/types": "^3.974.0",
+				"@smithy/core": "^3.29.2",
+				"@smithy/types": "^4.16.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/eventstream-handler-node": {
+			"version": "3.972.26",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.26.tgz",
+			"integrity": "sha512-RE1fu7Nn05vG0EUJM+8Sde2GFecC658WGaC/asPzLF6K4x3H5ZaDBcQtHRE67Gdgb1VZpyUUliYejHFK1qt0Uw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.974.0",
+				"@smithy/core": "^3.29.2",
+				"@smithy/types": "^4.16.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-eventstream": {
+			"version": "3.972.22",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.22.tgz",
+			"integrity": "sha512-jtkgmhevnpzC1WeS+Y/sgymYbaQ6qg7pVOUl5cUT/8MiLptqrtnXQlNV80m+j2WIx5MIL7kVHIZNxxcK2tfUEQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.974.0",
+				"@smithy/core": "^3.29.2",
+				"@smithy/types": "^4.16.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket": {
+			"version": "3.972.39",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.39.tgz",
+			"integrity": "sha512-CS1spxRSezmTmI3PD+3Xrnp6KryTSEz0EefA8u6uGd0s2I0uXseWHALDI/03Wi0IUczXNWo2QrZEaHDuJNby/Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.975.1",
+				"@aws-sdk/types": "^3.974.0",
+				"@smithy/core": "^3.29.2",
+				"@smithy/fetch-http-handler": "^5.6.4",
+				"@smithy/signature-v4": "^5.6.3",
+				"@smithy/types": "^4.16.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients": {
+			"version": "3.997.31",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.31.tgz",
+			"integrity": "sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.975.1",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.39",
+				"@aws-sdk/types": "^3.974.0",
+				"@smithy/core": "^3.29.2",
+				"@smithy/fetch-http-handler": "^5.6.4",
+				"@smithy/node-http-handler": "^4.9.4",
+				"@smithy/types": "^4.16.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.5.tgz",
+			"integrity": "sha512-bNqdxTQTxmLbomSmlkZFz8L6B/feQ2HHzw4L2zY7Ecp2XffYAZq2uzdWDdxJHJFbEvqd+SRuluJso0P8+xPdbw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.29.3",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/signature-v4-multi-region": {
+			"version": "3.996.39",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.39.tgz",
+			"integrity": "sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.974.0",
+				"@smithy/signature-v4": "^5.6.3",
+				"@smithy/types": "^4.16.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/token-providers": {
+			"version": "3.1048.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+			"integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/types": {
+			"version": "3.974.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.0.tgz",
+			"integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.16.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-locate-window": {
+			"version": "3.965.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz",
+			"integrity": "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/xml-builder": {
+			"version": "3.972.34",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
+			"integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.16.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws/lambda-invoke-store": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+			"integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+			"integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-agent-core": {
+			"version": "0.84.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.0.tgz",
+			"integrity": "sha512-L1lw0lwR5LXCzGEeHD9XNEruU2bg0H8clOA8ySdGMHvxutp8GC+yZL6MZp4tqQRnLKP3gHmY7TrWzQ3YnFdJYQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/pi-ai": "^0.84.0",
+				"@earendil-works/pi-telemetry": "^0.84.0",
+				"diff": "8.0.4",
+				"ignore": "7.0.5",
+				"typebox": "1.3.7",
+				"yaml": "2.9.0"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-ai": {
+			"version": "0.84.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.0.tgz",
+			"integrity": "sha512-N9RDk8q0eglGiy+NqTZ3Ev2j+6oFNXSAJa8b0CYhvWB9HGiKZjsoCESXkUvMDLybrn0wXp75sdsoBzEtHxk9kA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "3.1048.0",
+				"@earendil-works/pi-telemetry": "^0.84.0",
+				"@google/genai": "1.52.0",
+				"@mistralai/mistralai": "2.2.6",
+				"@opentelemetry/api": "1.9.0",
+				"@smithy/node-http-handler": "4.7.3",
+				"http-proxy-agent": "7.0.2",
+				"https-proxy-agent": "7.0.6",
+				"openai": "6.26.0",
+				"partial-json": "0.1.7",
+				"typebox": "1.3.7"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent": {
+			"version": "0.84.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.0.tgz",
+			"integrity": "sha512-oxEU7BT9xuVT6UKNwUNDzNP5dVGb+DZRGfaEyMyAab8dRlqTSxxyhSlMAxmYsu//YOeasj9E8n2+px1BzIai0g==",
+			"dev": true,
+			"hasShrinkwrap": true,
+			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/pi-agent-core": "^0.84.0",
+				"@earendil-works/pi-ai": "^0.84.0",
+				"@earendil-works/pi-client": "^0.84.0",
+				"@earendil-works/pi-protocol": "^0.84.0",
+				"@earendil-works/pi-tui": "^0.84.0",
+				"@silvia-odwyer/photon-node": "0.3.4",
+				"chalk": "5.6.2",
+				"cross-spawn": "7.0.6",
+				"diff": "8.0.4",
+				"glob": "13.0.6",
+				"grok-mermaid": "0.2.2",
+				"highlight.js": "10.7.3",
+				"hosted-git-info": "9.0.3",
+				"ignore": "7.0.5",
+				"jiti": "2.7.0",
+				"minimatch": "10.2.5",
+				"proper-lockfile": "4.1.2",
+				"semver": "7.8.0",
+				"typebox": "1.3.7",
+				"undici": "8.9.0",
+				"yaml": "2.9.0"
+			},
+			"bin": {
+				"pi": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard": "0.3.9"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
+			"version": "0.91.1",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+			"integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+			"integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-js": "^5.2.0",
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
+			"version": "3.1048.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+			"integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/credential-provider-node": "^3.972.42",
+				"@aws-sdk/eventstream-handler-node": "^3.972.16",
+				"@aws-sdk/middleware-eventstream": "^3.972.12",
+				"@aws-sdk/middleware-websocket": "^3.972.19",
+				"@aws-sdk/token-providers": "3.1048.0",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
+			"version": "3.974.11",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
+			"integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@aws-sdk/xml-builder": "^3.972.24",
+				"@aws/lambda-invoke-store": "^0.2.2",
+				"@smithy/core": "^3.24.2",
+				"@smithy/signature-v4": "^5.4.2",
+				"@smithy/types": "^4.14.1",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.972.37",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
+			"integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.972.39",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
+			"integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.972.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
+			"integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/credential-provider-env": "^3.972.37",
+				"@aws-sdk/credential-provider-http": "^3.972.39",
+				"@aws-sdk/credential-provider-login": "^3.972.41",
+				"@aws-sdk/credential-provider-process": "^3.972.37",
+				"@aws-sdk/credential-provider-sso": "^3.972.41",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.41",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/credential-provider-imds": "^4.3.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
+			"version": "3.972.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
+			"integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.972.42",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
+			"integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "^3.972.37",
+				"@aws-sdk/credential-provider-http": "^3.972.39",
+				"@aws-sdk/credential-provider-ini": "^3.972.41",
+				"@aws-sdk/credential-provider-process": "^3.972.37",
+				"@aws-sdk/credential-provider-sso": "^3.972.41",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.41",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/credential-provider-imds": "^4.3.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.972.37",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
+			"integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.972.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
+			"integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/token-providers": "3.1048.0",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.972.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
+			"integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
+			"version": "3.972.16",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
+			"integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
+			"version": "3.972.12",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
+			"integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
+			"version": "3.972.19",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
+			"integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/signature-v4": "^5.4.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
+			"version": "3.997.9",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
+			"integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.27",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
+			"version": "3.996.27",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+			"integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/signature-v4": "^5.4.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
+			"version": "3.1048.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+			"integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
+			"version": "3.973.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+			"integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
+			"version": "3.965.5",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+			"integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
+			"version": "3.972.24",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+			"integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@nodable/entities": "2.1.0",
+				"@smithy/types": "^4.14.1",
+				"fast-xml-parser": "5.7.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+			"integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
+			"version": "0.84.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.0.tgz",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/pi-ai": "^0.84.0",
+				"@earendil-works/pi-telemetry": "^0.84.0",
+				"diff": "8.0.4",
+				"ignore": "7.0.5",
+				"typebox": "1.3.7",
+				"yaml": "2.9.0"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
+			"version": "0.84.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.0.tgz",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "3.1048.0",
+				"@earendil-works/pi-telemetry": "^0.84.0",
+				"@google/genai": "1.52.0",
+				"@mistralai/mistralai": "2.2.6",
+				"@opentelemetry/api": "1.9.0",
+				"@smithy/node-http-handler": "4.7.3",
+				"http-proxy-agent": "7.0.2",
+				"https-proxy-agent": "7.0.6",
+				"openai": "6.26.0",
+				"partial-json": "0.1.7",
+				"typebox": "1.3.7"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-client": {
+			"version": "0.84.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.0.tgz",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/pi-protocol": "^0.84.0"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-protocol": {
+			"version": "0.84.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.0.tgz",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"typebox": "1.3.7"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-telemetry": {
+			"version": "0.84.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.0.tgz",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
+			"version": "0.84.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.0.tgz",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "1.6.0",
+				"marked": "18.0.5"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+			"integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"google-auth-library": "^10.3.0",
+				"p-retry": "^4.6.2",
+				"protobufjs": "^7.5.4",
+				"ws": "^8.18.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"@modelcontextprotocol/sdk": "^1.25.2"
+			},
+			"peerDependenciesMeta": {
+				"@modelcontextprotocol/sdk": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
+			"integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 10"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard-darwin-arm64": "0.3.9",
+				"@mariozechner/clipboard-darwin-universal": "0.3.9",
+				"@mariozechner/clipboard-darwin-x64": "0.3.9",
+				"@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
+				"@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
+				"@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
+				"@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
+				"@mariozechner/clipboard-linux-x64-musl": "0.3.9",
+				"@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
+				"@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
+			"integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
+			"integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
+			"integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
+			"integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
+			"integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
+			"integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
+			"integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
+			"integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
+			"integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
+			"integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+			"integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.40.0",
+				"ws": "^8.18.0",
+				"zod": "^3.25.0 || ^4.0.0",
+				"zod-to-json-schema": "^3.25.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.9.0"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+			"integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodable"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.41.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+			"integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+			"integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+			"integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.1"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+			"integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+			"integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
+			"version": "3.24.3",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+			"integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/crc32": "5.2.0",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+			"integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
+			"version": "5.4.3",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+			"integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
+			"version": "4.7.3",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+			"integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
+			"version": "5.4.3",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+			"integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
+			"version": "4.14.2",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+			"integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
+			"version": "22.19.19",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+			"integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+			"integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+			"integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+			"integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"path-expression-matcher": "^1.5.0",
+				"xml-naming": "^0.1.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
+			"version": "5.7.3",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+			"integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@nodable/entities": "^2.1.0",
+				"fast-xml-builder": "^1.1.7",
+				"path-expression-matcher": "^1.5.0",
+				"strnum": "^2.2.3"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+			"integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^7.0.1",
+				"node-fetch": "^3.3.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
+			"version": "8.1.2",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+			"integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"gaxios": "^7.0.0",
+				"google-logging-utils": "^1.0.0",
+				"json-bigint": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
+			"version": "10.6.2",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+			"integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"base64-js": "^1.3.0",
+				"ecdsa-sig-formatter": "^1.0.11",
+				"gaxios": "^7.1.4",
+				"gcp-metadata": "8.1.2",
+				"google-logging-utils": "1.1.3",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+			"integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/grok-mermaid": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/grok-mermaid/-/grok-mermaid-0.2.2.tgz",
+			"integrity": "sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
+			"version": "10.7.3",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+			"integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/hosted-git-info": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+			"integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"lru-cache": "^11.1.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bignumber.js": "^9.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"ts-algebra": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer-equal-constant-time": "^1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jwa": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
+			"version": "11.4.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+			"integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
+			"version": "18.0.5",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+			"integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"deprecated": "Use your platform's native DOMException instead",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+			"integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/retry": "0.12.0",
+				"retry": "^0.13.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+			"integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+			"integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+			"integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"retry": "^0.12.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile/node_modules/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
+			"version": "7.6.5",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+			"integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.5",
+				"@protobufjs/eventemitter": "^1.1.1",
+				"@protobufjs/fetch": "^1.1.1",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.1",
+				"@types/node": ">=13.7.0",
+				"long": "^5.3.2"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+			"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+			"integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
+			"license": "0BSD"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+			"integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
+			"version": "8.9.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+			"integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+			"integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
+			"version": "3.25.76",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"dev": true,
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.25.28 || ^4"
+			}
+		},
+		"node_modules/@earendil-works/pi-telemetry": {
+			"version": "0.84.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.0.tgz",
+			"integrity": "sha512-g6hLxEfAUk3zJlDmFWhWHJNcYXYiNGeWuJC9YkcHpkdkj0gxD4uaMNNNU3QsAEJXW9Qcxnl21+U8GfhVsc8C5g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-tui": {
+			"version": "0.84.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.0.tgz",
+			"integrity": "sha512-nbs0FeZJ5rWDD6VpKfXXmYbEHnHqb40V9glE2l9f8ftoWpsP8nw0WcXK8jOjfRsDPnT9dJHy3dItOHdn/AFGjA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "1.6.0",
+				"marked": "18.0.5"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+			"integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+			"integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+			"integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+			"integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+			"integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+			"integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+			"integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+			"integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+			"integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+			"integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+			"integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+			"integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+			"integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+			"integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+			"integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+			"integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+			"integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+			"integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+			"integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+			"integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@google/genai": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+			"integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"google-auth-library": "^10.3.0",
+				"p-retry": "^4.6.2",
+				"protobufjs": "^7.5.4",
+				"ws": "^8.18.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"@modelcontextprotocol/sdk": "^1.25.2"
+			},
+			"peerDependenciesMeta": {
+				"@modelcontextprotocol/sdk": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@mistralai/mistralai": {
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+			"integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.40.0",
+				"ws": "^8.18.0",
+				"zod": "^3.25.0 || ^4.0.0",
+				"zod-to-json-schema": "^3.25.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.9.0"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@opentelemetry/api": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+			"integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/codegen": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/eventemitter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+			"integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/fetch": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+			"integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.1"
+			}
+		},
+		"node_modules/@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/utf8": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+			"integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@rollup/rollup-android-arm-eabi": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+			"integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-android-arm64": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+			"integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-arm64": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+			"integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-x64": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+			"integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-arm64": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+			"integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-x64": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+			"integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+			"integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+			"integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-gnu": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+			"integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-musl": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+			"integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-gnu": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+			"integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-musl": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+			"integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+			"integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-musl": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+			"integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+			"integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-musl": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+			"integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-s390x-gnu": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+			"integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-gnu": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+			"integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-musl": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+			"integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-openbsd-x64": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+			"integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			]
+		},
+		"node_modules/@rollup/rollup-openharmony-arm64": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+			"integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-arm64-msvc": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+			"integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-ia32-msvc": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+			"integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-gnu": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+			"integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-msvc": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+			"integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@smithy/core": {
+			"version": "3.29.3",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.3.tgz",
+			"integrity": "sha512-L+Ys6ecjk5vwPMAKHBpPKlJ3DkqwNcnfEISXBZIsVvWG/XKXfsAP8mwIYlTeLcd2ElHdesPI8OuOmJSFAPhm6A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/credential-provider-imds": {
+			"version": "4.4.8",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.8.tgz",
+			"integrity": "sha512-q9J7JTiXrAhB8sDp4px97uEPT7CwKH61Co78grdNQvU8QZAdiuaSRhP0tUVf2ogy36RZTrlMU1rBmDEH+cnkiA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.29.3",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/fetch-http-handler": {
+			"version": "5.6.5",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.5.tgz",
+			"integrity": "sha512-SuqeisTyPoiIPtIYru/sGxGyXzmZ+8nnFOhC+qRPglt06Ebd1yH//CDltZB2J/3WBNVhwfUaZ0EtHB3cm2X32g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.29.3",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/node-http-handler": {
+			"version": "4.7.3",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+			"integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/signature-v4": {
+			"version": "5.6.4",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.4.tgz",
+			"integrity": "sha512-B89bpf2t/y/wia6LZ+4JfHXYQT9PnVftsH05rgJKKIStS7r/4XSs9HOjtPoLtgcA6HCW9jVqX5DBbq7E0PAkiQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.29.3",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/types": {
+			"version": "4.16.1",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+			"integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
+			}
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "22.20.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+			"integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/@types/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@vitest/expect": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+			"integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "3.2.7",
+				"@vitest/utils": "3.2.7",
+				"chai": "^5.2.0",
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+			"integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "3.2.7",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.17"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+			"integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+			"integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "3.2.7",
+				"pathe": "^2.0.3",
+				"strip-literal": "^3.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+			"integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "3.2.7",
+				"magic-string": "^0.30.17",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+			"integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyspy": "^4.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+			"integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "3.2.7",
+				"loupe": "^3.1.4",
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/bignumber.js": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/bowser": {
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+			"integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/cac": {
+			"version": "6.7.14",
+			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/chai": {
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+			"integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"assertion-error": "^2.0.1",
+				"check-error": "^2.1.1",
+				"deep-eql": "^5.0.1",
+				"loupe": "^3.1.0",
+				"pathval": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/check-error": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+			"integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16"
+			}
+		},
+		"node_modules/data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/deep-eql": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/diff": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+			"integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/es-module-lexer": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/esbuild": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+			"integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.28.1",
+				"@esbuild/android-arm": "0.28.1",
+				"@esbuild/android-arm64": "0.28.1",
+				"@esbuild/android-x64": "0.28.1",
+				"@esbuild/darwin-arm64": "0.28.1",
+				"@esbuild/darwin-x64": "0.28.1",
+				"@esbuild/freebsd-arm64": "0.28.1",
+				"@esbuild/freebsd-x64": "0.28.1",
+				"@esbuild/linux-arm": "0.28.1",
+				"@esbuild/linux-arm64": "0.28.1",
+				"@esbuild/linux-ia32": "0.28.1",
+				"@esbuild/linux-loong64": "0.28.1",
+				"@esbuild/linux-mips64el": "0.28.1",
+				"@esbuild/linux-ppc64": "0.28.1",
+				"@esbuild/linux-riscv64": "0.28.1",
+				"@esbuild/linux-s390x": "0.28.1",
+				"@esbuild/linux-x64": "0.28.1",
+				"@esbuild/netbsd-arm64": "0.28.1",
+				"@esbuild/netbsd-x64": "0.28.1",
+				"@esbuild/openbsd-arm64": "0.28.1",
+				"@esbuild/openbsd-x64": "0.28.1",
+				"@esbuild/openharmony-arm64": "0.28.1",
+				"@esbuild/sunos-x64": "0.28.1",
+				"@esbuild/win32-arm64": "0.28.1",
+				"@esbuild/win32-ia32": "0.28.1",
+				"@esbuild/win32-x64": "0.28.1"
+			}
+		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+			"integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
+			}
+		},
+		"node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/gaxios": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.2.0.tgz",
+			"integrity": "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^7.0.1",
+				"node-fetch": "^3.3.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/gcp-metadata": {
+			"version": "8.1.2",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+			"integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"gaxios": "^7.0.0",
+				"google-logging-utils": "^1.0.0",
+				"json-bigint": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/get-east-asian-width": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/google-auth-library": {
+			"version": "10.9.0",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
+			"integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"base64-js": "^1.3.0",
+				"ecdsa-sig-formatter": "^1.0.11",
+				"gaxios": "^7.1.4",
+				"gcp-metadata": "8.1.2",
+				"google-logging-utils": "1.1.3",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/google-logging-utils": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+			"integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/js-tokens": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+			"integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/json-bigint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bignumber.js": "^9.0.0"
+			}
+		},
+		"node_modules/json-schema-to-ts": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"ts-algebra": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/jwa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer-equal-constant-time": "^1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jws": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jwa": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/long": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/loupe": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+			"integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/magic-string": {
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/marked": {
+			"version": "18.0.5",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+			"integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/nanoid": {
+			"version": "3.3.16",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"deprecated": "Use your platform's native DOMException instead",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
+			}
+		},
+		"node_modules/openai": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+			"integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/p-retry": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/retry": "0.12.0",
+				"retry": "^0.13.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/partial-json": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+			"integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/pathval": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+			"integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.16"
+			}
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/picomatch": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/postcss": {
+			"version": "8.5.18",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+			"integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.12",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/protobufjs": {
+			"version": "7.6.5",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+			"integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.5",
+				"@protobufjs/eventemitter": "^1.1.1",
+				"@protobufjs/fetch": "^1.1.1",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.1",
+				"@types/node": ">=13.7.0",
+				"long": "^5.3.2"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/retry": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/rollup": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+			"integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "1.0.9"
+			},
+			"bin": {
+				"rollup": "dist/bin/rollup"
+			},
+			"engines": {
+				"node": ">=18.0.0",
+				"npm": ">=8.0.0"
+			},
+			"optionalDependencies": {
+				"@rollup/rollup-android-arm-eabi": "4.62.2",
+				"@rollup/rollup-android-arm64": "4.62.2",
+				"@rollup/rollup-darwin-arm64": "4.62.2",
+				"@rollup/rollup-darwin-x64": "4.62.2",
+				"@rollup/rollup-freebsd-arm64": "4.62.2",
+				"@rollup/rollup-freebsd-x64": "4.62.2",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+				"@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+				"@rollup/rollup-linux-arm64-gnu": "4.62.2",
+				"@rollup/rollup-linux-arm64-musl": "4.62.2",
+				"@rollup/rollup-linux-loong64-gnu": "4.62.2",
+				"@rollup/rollup-linux-loong64-musl": "4.62.2",
+				"@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+				"@rollup/rollup-linux-ppc64-musl": "4.62.2",
+				"@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+				"@rollup/rollup-linux-riscv64-musl": "4.62.2",
+				"@rollup/rollup-linux-s390x-gnu": "4.62.2",
+				"@rollup/rollup-linux-x64-gnu": "4.62.2",
+				"@rollup/rollup-linux-x64-musl": "4.62.2",
+				"@rollup/rollup-openbsd-x64": "4.62.2",
+				"@rollup/rollup-openharmony-arm64": "4.62.2",
+				"@rollup/rollup-win32-arm64-msvc": "4.62.2",
+				"@rollup/rollup-win32-ia32-msvc": "4.62.2",
+				"@rollup/rollup-win32-x64-gnu": "4.62.2",
+				"@rollup/rollup-win32-x64-msvc": "4.62.2",
+				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/std-env": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/strip-literal": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+			"integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"js-tokens": "^9.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
+		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+			"integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinypool": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+			"integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.0.0 || >=20.0.0"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+			"integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tinyspy": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+			"integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/ts-algebra": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
+			"license": "0BSD"
+		},
+		"node_modules/typebox": {
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+			"integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/vite": {
+			"version": "7.3.6",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+			"integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "^0.27.0 || ^0.28.0",
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3",
+				"postcss": "^8.5.6",
+				"rollup": "^4.43.0",
+				"tinyglobby": "^0.2.15"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"lightningcss": "^1.21.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"lightningcss": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vite-node": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+			"integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cac": "^6.7.14",
+				"debug": "^4.4.1",
+				"es-module-lexer": "^1.7.0",
+				"pathe": "^2.0.3",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+			},
+			"bin": {
+				"vite-node": "vite-node.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/vitest": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+			"integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/chai": "^5.2.2",
+				"@vitest/expect": "3.2.7",
+				"@vitest/mocker": "3.2.7",
+				"@vitest/pretty-format": "^3.2.7",
+				"@vitest/runner": "3.2.7",
+				"@vitest/snapshot": "3.2.7",
+				"@vitest/spy": "3.2.7",
+				"@vitest/utils": "3.2.7",
+				"chai": "^5.2.0",
+				"debug": "^4.4.1",
+				"expect-type": "^1.2.1",
+				"magic-string": "^0.30.17",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.2",
+				"std-env": "^3.9.0",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^0.3.2",
+				"tinyglobby": "^0.2.14",
+				"tinypool": "^1.1.1",
+				"tinyrainbow": "^2.0.0",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+				"vite-node": "3.2.4",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@types/debug": "^4.1.12",
+				"@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+				"@vitest/browser": "3.2.7",
+				"@vitest/ui": "3.2.7",
+				"happy-dom": "*",
+				"jsdom": "*"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@types/debug": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/web-streams-polyfill": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ws": {
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/yaml": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"node_modules/zod": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-to-json-schema": {
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"dev": true,
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.25.28 || ^4"
+			}
+		}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,41 +1,44 @@
 {
- "name": "pi-hydra",
- "version": "0.1.0",
- "description": "Extra heads for your pi coding agent: live oversight through prompt-cache replay",
- "keywords": [
-  "pi-package",
-  "pi",
-  "extension",
-  "code-review",
-  "prompt-caching"
- ],
- "repository": {
-  "type": "git",
-  "url": "git+https://github.com/pandysp/pi-hydra.git"
- },
- "license": "MIT",
- "type": "module",
- "private": true,
- "pi": {
-  "image": "https://raw.githubusercontent.com/pandysp/pi-hydra/main/docs/assets/demo.gif",
-  "extensions": [
-   "./index.ts"
-  ]
- },
- "scripts": {
-  "check": "tsc",
-  "test": "vitest run"
- },
- "devDependencies": {
-  "@earendil-works/pi-agent-core": "0.82.0",
-  "@types/node": "^22",
-  "typescript": "^5.7",
-  "vitest": "^3"
- },
- "peerDependencies": {
-  "@earendil-works/pi-agent-core": "*",
-  "@earendil-works/pi-ai": "*",
-  "@earendil-works/pi-coding-agent": "*",
-  "@earendil-works/pi-tui": "*"
- }
+	"name": "pi-hydra",
+	"version": "0.1.0",
+	"description": "Extra heads for your pi coding agent: live oversight through prompt-cache replay",
+	"keywords": [
+		"pi-package",
+		"pi",
+		"extension",
+		"code-review",
+		"prompt-caching"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/pandysp/pi-hydra.git"
+	},
+	"license": "MIT",
+	"type": "module",
+	"private": true,
+	"pi": {
+		"image": "https://raw.githubusercontent.com/pandysp/pi-hydra/main/docs/assets/demo.gif",
+		"extensions": [
+			"./index.ts"
+		]
+	},
+	"scripts": {
+		"check": "tsc",
+		"test": "vitest run"
+	},
+	"devDependencies": {
+		"@earendil-works/pi-agent-core": "^0.84.0",
+		"@earendil-works/pi-ai": "^0.84.0",
+		"@earendil-works/pi-coding-agent": "^0.84.0",
+		"@earendil-works/pi-tui": "^0.84.0",
+		"@types/node": "^22",
+		"typescript": "^5.7",
+		"vitest": "^3"
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-agent-core": "*",
+		"@earendil-works/pi-ai": "*",
+		"@earendil-works/pi-coding-agent": "*",
+		"@earendil-works/pi-tui": "*"
+	}
 }


### PR DESCRIPTION
## The bug

Observations called pi-ai's `compat.streamSimple` directly. That always reaches the builtin
provider, because it short-circuits to `getBuiltinProviderForModel(model)` before consulting the
api registry — and pi keeps extension provider overrides in its **own model runtime**
(`registerApiProvider` appears nowhere in pi's dist).

So a provider-wrapping extension shapes the driver's requests, which resolve through pi's runtime,
while hydra's observations bypass it entirely.

Reproduced with [`pi-anthropic-auth`](https://github.com/gotgenes/pi-anthropic-auth) on a Claude
subscription: driver turns returned `200`, while **every observation** was rejected with
`400 "You're out of extra usage"`. Hydra printed `observation failed` and carried on — observations
were lost **silently**.

## What's in here

1. **Resolve the observation transport through pi's provider overrides** —
   `ModelRegistry.getRegisteredProviderConfig()`, mirroring pi's own composition guard so an
   extension transport is used only for the api it registered for. That method is not a documented
   extension surface, so a missing method, unexpected shape, or non-function transport all fall
   back to the compat helper rather than throwing inside every observation.
2. **Track pi 0.84 and its `ProviderHeaders` contract** — 0.84 returns `string | null` headers and
   preserves null deletion markers, so `Record<string, string>` no longer typechecks. Adopt
   `ProviderHeaders` and keep forwarding it unchanged, as pi documents.
3. **Apply an auth-supplied `baseUrl` to the observation model** — pi's runtime substitutes it
   before streaming and transports read `model.baseUrl`; `ctx.model` is unsubstituted, so an
   observation would bypass a gateway the driver goes through.

## Failure diagnosis, without false alarms

Having no override is the **normal** case, so its absence is not warned about on its own. It is
appended as a hint only when an observation is actually rejected, and is derived from the transport
that was *used* rather than a second lookup that could disagree with it.

## Verified

Tool-calling turns with `pi-anthropic-auth` loaded, tool execution confirmed by filesystem side
effect:

| | before | after |
|---|---|---|
| driver requests | `200` | `200` |
| observation requests | **`400` out of extra usage** | **`200`** |
| `observation failed` lines | 2 | **0** |

- **pi 0.84**: 4/4 requests on the subscription, 0 failures — including a run with hydra's own
  `pi-ai` removed, forcing 0.84 resolution, to rule out a mixed tree.
- **pi 0.82**: 4/4, 0 failures, across repeated runs — back-compat is runtime-proven, not just a
  typecheck.
- `tsc --noEmit` clean against **both** 0.82 and 0.84; 133 tests pass.
- All five fallback branches unit-checked; none throw. The hint was confirmed to fire by forcing
  the lookup to miss, and stays silent on green runs.

## Not verified

- **The `baseUrl` change (commit 3).** No provider supplying a baseUrl through auth was available
  to test against; it is reasoned from pi's source. Reviewers with a gateway-backed provider should
  confirm. Its override is also computed once per observation, so a baseUrl changing mid-loop is not
  picked up — matching the pre-existing handling of the api key.
- The `openai-codex-responses` observation path. The api guard should make it fall back safely, but
  Codex quota was exhausted, and hydra uses a websocket transport there, so verification needs
  hydra-side logging rather than HTTP interception.
- An override correctly applied on a **non-anthropic** api — no existing extension registers one.
- pi's `lazyStream` wrapper, which this bypasses by calling the transport directly. Equivalent for
  immediate `.result()` consumption in every run observed, not proven equivalent in general.
