### PR TITLE
docs: make pi-hydra understandable in two minutes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ If you installed hydra via the README quickstart, run `pi remove git:github.com/
 Edit, then reload pi (Ctrl-R or `/reload`) to pick up changes. If you move the clone, recreate the symlink: pi skips a dangling extension link silently, and hydra stops existing (no commands, no flags, no observations). Before sending a PR:
 
 ```bash
-npm run check    # tsc --strict, plus the module-state gate
+npm run check    # tsc, module-state, links, and code-to-doc claims
 npm test         # vitest on the root modules
 ```
 
@@ -27,13 +27,15 @@ Smoke-test delivery with the hidden diagnostic heads: `/hydra-heads test` forces
 
 - New example heads; prototype them as head files (`~/.pi/agent/hydra/`, see [`docs/heads.md`](docs/heads.md)) and PR the ones that prove themselves into [`heads/`](heads)
 - Steps toward mid-generation interrupts (see "Where this is going" in the README)
-- Provider support beyond Anthropic and OpenAI Codex (needs a cache-parity story; read [`docs/architecture.md`](docs/architecture.md) first)
+- Provider support beyond Anthropic and OpenAI Codex (needs a cache-parity story; read [`docs/providers.md`](docs/providers.md) first)
 - Replications or extensions of the [`experiments/`](https://github.com/pandysp/pi-hydra/blob/openai-cache-clean/experiments/INDEX.md)
 
 ## The bar
 
-- Every claim about cache behavior must be backed by a measurement. The cache probes re-verify the mechanism against the live APIs, and a full cache-probe run costs under a dollar.
-- If your change touches the replay or marker logic, run the verification procedures in [`docs/architecture.md`](docs/architecture.md) (cache parity, the headless cacheRead check, and the tripwire when transport logic is touched) and put the numbers in the PR.
+- Every claim about cache behavior must be backed by a measurement. [`docs/providers.md`](docs/providers.md) is the canonical owner of provider behavior, economics, dates, and evidence; other outward docs summarize and link to it.
+- If your change touches replay or marker logic, run the procedures in [`docs/providers.md`](docs/providers.md#verification-procedures) (cache parity, the headless cacheRead check, and the tripwire when transport logic is touched) and put the numbers in the PR.
+- `npm run check:links` validates local Markdown files and GitHub-compatible heading fragments, including the committed inventory of inbound links discovered outside this repository.
+- `npm run check:docs` binds public claims to both narrow code authority regions and canonical documentation sections. If either changes intentionally, review both sides and update only the affected claim explicitly: `npm run update:doc-claims -- --reviewed --claim=<id>`.
 - Pure logic goes in the matching root module with tests (`protocol.ts`, `delivery.ts`, `heads.ts`, `scheduler.ts`, `stats.ts`, `utils.ts`).
 - Match the style of the file you are editing.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![A Pi session where the head picker adds a security head; while Pi builds a Flask app, that head catches debug mode and an open-redirect risk and steers the fixes into the conversation](docs/assets/demo.gif)
 
-hydra is a [pi](https://pi.dev/) extension for live oversight. Pi remains the one coding agent doing the work; specialist **heads** watch the same trajectory through different lenses and can stay quiet, show you a note, steer Pi at its next checkpoint, interrupt an unsafe run, or use permitted tools before deciding.
+hydra is a [pi](https://pi.dev/) extension for live oversight. Pi remains the primary driver you talk to; specialist **heads** watch its trajectory through different lenses and can stay quiet, show you a note, steer Pi at its next checkpoint, interrupt an unsafe run, or use permitted tools before deciding.
 
 ```text
                          security head
@@ -15,7 +15,7 @@ user ─────► Pi driver ────────┼──────�
               │               │
               │          quality head
               │
-              └──── shared cached context
+              └──── captured provider context
 ```
 
 One body, many heads.
@@ -30,22 +30,22 @@ hydra attaches another perspective to context that already exists:
 capture Pi's request → append a specialist handoff → review → deliver
 ```
 
-The head receives Pi's real provider trajectory, not a summary. Most of that trajectory can be read from the prompt cache, so the fresh input is mainly the head's instruction and recent tail. A consequential mistake can therefore be caught while correction is still one message rather than a refactor.
+The head receives Pi's real provider trajectory, not a summary. On healthy measured cache paths, most of that trajectory is a cache read, so fresh input is concentrated in the head's instruction and recent tail. A consequential mistake can therefore be caught while correction is still one message rather than a refactor.
 
 ## How it works
 
 1. Pi prepares a model request containing its conversation, tools, and results.
 2. hydra captures that provider payload rather than rebuilding the context.
 3. At a review point, hydra appends a short handoff for each active head.
-4. Every head reviews independently through its own Markdown instruction.
-5. hydra validates the result and routes it to you or Pi.
-6. The footer and `/hydra-stats` record observations, cache use, and cost.
+4. Every head runs independently through its own Markdown instruction; a busy head may skip superseded intermediate snapshots.
+5. hydra validates the decision and either shows you a note, feeds it to the driver, or delivers nothing.
+6. Accepted observation calls, cache use, and cost are recorded in Pi's session and shown in the footer and `/hydra-stats`.
 
 Anthropic and OpenAI Codex need different handoffs and have different cache behavior. The system flow is in [Architecture](docs/architecture.md); provider mechanics, measurements, and economics have one canonical home in [Providers and measurements](docs/providers.md).
 
 ## Quick start
 
-You need [pi](https://pi.dev/) with an Anthropic model or an OpenAI Codex model supported by the measured provider gate.
+You need [pi](https://pi.dev/) with an Anthropic or OpenAI Codex model. The runtime gate is provider/API based; validated model coverage and economics are listed in [Supported provider boundary](docs/providers.md#supported-provider-boundary).
 
 ```bash
 pi install git:github.com/pandysp/pi-hydra
@@ -54,7 +54,7 @@ cp ~/.pi/agent/git/github.com/pandysp/pi-hydra/heads/*.md ~/.pi/agent/hydra/
 pi
 ```
 
-The example `quality` head is marked `autostart`, so observations begin in a fresh session. For team-wide installation, `pi install -l` records the package in the repository's `.pi/settings.json`. Development setup is in [CONTRIBUTING.md](CONTRIBUTING.md).
+The example `quality` head is marked `autostart`, so it is active at the first eligible observation point of a fresh session. For team-wide installation, `pi install -l` records the package in the repository's `.pi/settings.json`. Development setup is in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 Choose heads at any time:
 
@@ -100,12 +100,12 @@ A judge-only head can return several independent findings in one review. hydra g
 
 | decision | effect |
 |---|---|
-| `print` | Show a note in the TUI; Pi never sees it. |
+| `print` | Show a note in the interactive TUI; it never enters the driver's context. |
 | `steer` | Deliver a real user message at Pi's next checkpoint. This is the normal agent-directed route. |
-| `interrupt` | Abort the current run and deliver the finding. This is the emergency cord. |
+| `interrupt` | Abort an active run and deliver the finding; when idle, start the next run with it. This is the emergency cord. |
 | no finding | Deliver nothing; `/hydra-stats` records a noop. |
 
-Acting heads can inspect or change the workspace through their allowed tools before making that decision. The old queue route remains internal for compatibility but is not offered to current heads.
+An interrupt from a snapshot the driver has already moved past is demoted to steer rather than aborting newer work. Acting heads can inspect or change the workspace through their allowed tools before deciding. The old queue route remains internal for compatibility but is not offered to current heads.
 
 ## Heads and subagents solve different problems
 
@@ -147,7 +147,7 @@ The current measured ranges, dated evidence, model coverage, and provider-specif
 
 ## Where this is going
 
-The main open direction is mid-generation observation. Today hydra judges committed request snapshots, so it can steer between turns but cannot evaluate an unfinished response while it streams. Doing that would require reasoning over partial output without prompt-cache parity.
+The main open direction is mid-generation observation. Today hydra judges complete captured requests, so it can steer between turns but cannot evaluate an unfinished response while it streams. Doing that would require reasoning over partial output without prompt-cache parity.
 
 ## History
 

--- a/README.md
+++ b/README.md
@@ -4,136 +4,154 @@
 
 > Extra heads for your coding agent.
 
-![A pi session: the head picker adds a security head, then as the agent builds a Flask app the security head catches debug=True (a Werkzeug RCE) and an open-redirect risk and steers the fix into the conversation](docs/assets/demo.gif)
+![A Pi session where the head picker adds a security head; while Pi builds a Flask app, that head catches debug mode and an open-redirect risk and steers the fixes into the conversation](docs/assets/demo.gif)
 
-hydra is a [pi](https://pi.dev/) extension that adds live oversight to your coding agent: heads that review the agent's work while the agent is still working. Each head reviews through its own lens (quality, security, simplifier, API design, or anything you write). It sees exactly what the agent sees, judges every step, and delivers each finding: print a note for you, steer the agent at its next checkpoint, or interrupt the run. Heads can act, too: by default a head may read, search, run, and write through the agent's own tools before it decides (a docs head keeps notes current while the agent codes). One body, many heads: the agent carries the context, and each additional head reads that context straight from the prompt cache. An observation costs a cache read instead of a context rebuild; total overhead depends on provider, task, and how much the head reports ([What it costs](#what-it-costs)).
+hydra is a [pi](https://pi.dev/) extension for live oversight. Pi remains the one coding agent doing the work; specialist **heads** watch the same trajectory through different lenses and can stay quiet, show you a note, steer Pi at its next checkpoint, interrupt an unsafe run, or use permitted tools before deciding.
+
+```text
+                         security head
+                              │
+user ─────► Pi driver ────────┼──────► code and tool work
+              │               │
+              │          quality head
+              │
+              └──── shared cached context
+```
+
+One body, many heads.
 
 ## Why
 
-Review usually happens after the work. The PR is finished, a reviewer (human or agent) loads the whole trajectory into fresh context at full price, and the findings arrive when the design is already set, so fixing them means rework. The same goes for evaluating agent behavior: replaying a finished trajectory into an eval agent costs full input price and happens too late to change anything.
+A normal second agent first has to learn the project, task, conversation, and recent work. That duplicates context and creates a handoff before the reviewer contributes anything.
 
-hydra inverts this. Observation happens during the run, at the exact moments the agent's own prompt cache commits, so a second perspective costs the observation prompt plus a cache read (numbers in [What it costs](#what-it-costs)). The decision usually lands while the agent's response is still streaming, early enough to steer the next step instead of rewriting a finished PR.
+hydra attaches another perspective to context that already exists:
 
-A bad assumption caught mid-implementation costs one correction message, and the same assumption caught in review costs a refactor.
+```text
+capture Pi's request → append a specialist handoff → review → deliver
+```
 
-## What it costs
+The head receives Pi's real provider trajectory, not a summary. Most of that trajectory can be read from the prompt cache, so the fresh input is mainly the head's instruction and recent tail. A consequential mistake can therefore be caught while correction is still one message rather than a refactor.
 
-An observation pays for its fresh handoff and output plus a cache read. Measured cache hit rates are 97%+ across real Anthropic sessions (a 17K-token session measured 99%); OpenAI Codex measures ~84–87% ([why](docs/architecture.md#cache-hit-ratio)).
+## How it works
 
-A session costs more than one observation suggests because an always-on head watches every cache commit. On live Anthropic sessions, an always-on head cost between 32.5% and 61.4% of what the driver itself cost (the driver is pi's main agent, the one you talk to). On OpenAI Codex, the registered measurement wave put the shipped judge contract at 77.0% of driver cost over its 108 cache-comparable observations, and a single-finding baseline contract at 52.1% over 103; keeping every charged call, cache misses included, raises those ratios to 93.3% and 66.2%. These are measured regimes, not a universal surcharge, and the OpenAI values are cost evidence only: the quality benchmark is still in progress. Output volume, task, model, and reasoning level all move the number. Per-arm and per-configuration numbers are in the [decision table](https://github.com/pandysp/pi-hydra/blob/openai-cache-clean/experiments/DECISION-TABLE.md); `/hydra-stats` shows the same accounting for your own session.
+1. Pi prepares a model request containing its conversation, tools, and results.
+2. hydra captures that provider payload rather than rebuilding the context.
+3. At a review point, hydra appends a short handoff for each active head.
+4. Every head reviews independently through its own Markdown instruction.
+5. hydra validates the result and routes it to you or Pi.
+6. The footer and `/hydra-stats` record observations, cache use, and cost.
 
-The harness in [`experiments/`](https://github.com/pandysp/pi-hydra/blob/openai-cache-clean/experiments/INDEX.md) re-verifies the cache mechanism these numbers rest on against the live APIs: when an entry commits, what an observation can see, and whether the replay stays on the cache. The hit rates and costs above come from real sessions, and `/hydra-stats` shows the same numbers live for your own.
-
-## Compared to subagents
-
-pi's core ships four tools and no subagents; heads and subagents both arrive as extensions, and they sit at opposite ends of two coupled choices: where the reviewer's context comes from, and how its run relates to the driver's. On context, a head rides the driver's exact prompt cache, so it is locked to the driver's model and costs a cache read; a subagent ([pi-subagents](https://github.com/tintinweb/pi-subagents)) rebuilds context from scratch, so it picks any model and pays full input price. On the run, a head *watches in place*, replaying at the driver's commit points and able to act on what it sees live; a subagent is *spawned and returns*: it runs on its own clock and hands back a result the parent reads when it is done.
-
-| | subagents | hydra heads |
-|---|---|---|
-| Context | fresh, isolated by default; zero anchoring to the driver's assumptions | the driver's payload byte-for-byte; fully anchored to the driver's assumptions |
-| Model | free: a stronger model for a real second opinion, or a cheap one for grunt work | locked to the driver's, always (the cache is model-specific) |
-| Cost | a full-price context rebuild per review | a cache read plus the head's fresh handoff and output per observation; session overhead varies materially by provider and task |
-| Timing | on its own clock: Explore, Plan, a parallel worktree refactor, or a finished-artifact audit | live, at the driver's commit points, in time to steer the next step |
-| Direction | spawned downward; can be `steer`ed downward (parent → child) and returns a final message | watches the same run; can `steer` or pull the cord upward (head → agent) |
-| What crosses | passive data, inert until the parent reads and acts on it | an act: a `steer` or `interrupt` that fires whether the agent agrees or not |
-
-Reach for a subagent when fresh eyes, a stronger model, or heavy isolated work is the point; reach for a head to catch a bad turn during the run. The two stack around the driver: heads steer it from above, and it spawns subagents for the isolated work below.
+Anthropic and OpenAI Codex need different handoffs and have different cache behavior. The system flow is in [Architecture](docs/architecture.md); provider mechanics, measurements, and economics have one canonical home in [Providers and measurements](docs/providers.md).
 
 ## Quick start
 
-You need [pi](https://pi.dev/) with an Anthropic model or an OpenAI Codex (ChatGPT subscription) model. Cache-parity replay is validated on Anthropic models and on codex GPT-5.6; older codex models are not blocked, but their cache economics are unmeasured. The economics differ per provider ([details](docs/architecture.md#openai-codex-support)).
+You need [pi](https://pi.dev/) with an Anthropic model or an OpenAI Codex model supported by the measured provider gate.
 
 ```bash
 pi install git:github.com/pandysp/pi-hydra
-mkdir -p ~/.pi/agent/hydra && cp ~/.pi/agent/git/github.com/pandysp/pi-hydra/heads/*.md ~/.pi/agent/hydra/
+mkdir -p ~/.pi/agent/hydra
+cp ~/.pi/agent/git/github.com/pandysp/pi-hydra/heads/*.md ~/.pi/agent/hydra/
 pi
 ```
 
-The copy reads from the clone `pi install` just made, so the examples match the installed version. You can also skip the copy and ask your agent to write a head; the `hydra` tool teaches it the format. To install for your whole team, `pi install -l` records the package in the repo's `.pi/settings.json`, and pi installs it for everyone on startup. For development setup, see [CONTRIBUTING.md](CONTRIBUTING.md).
+The example `quality` head is marked `autostart`, so observations begin in a fresh session. For team-wide installation, `pi install -l` records the package in the repository's `.pi/settings.json`. Development setup is in [CONTRIBUTING.md](CONTRIBUTING.md).
 
-The example `quality` head is marked `autostart`, so after the first agent run you will see observations arrive in the footer:
+Choose heads at any time:
 
-```
-hydra:quality hit 98.5% (last 99.1%) $0.0234 (12 obs)
-```
-
-Add or remove heads at any time:
-
-```
-/hydra-heads                     # multi-select picker over every head you have
-/hydra-heads quality,security    # or set the active heads directly
+```text
+/hydra-heads                     open the picker
+/hydra-heads quality,security    set the active heads
+/hydra-heads none                observe with no heads
 ```
 
-### Heads are files
+For headless runs, use `--hydra-heads quality,security`.
 
-A head is one markdown file: frontmatter for identity and capabilities, body for the instruction.
+## Heads are Markdown files
 
 ```markdown
 ---
 name: docs-keeper
-description: Keeps docs/notes.md current with decisions as they happen
-tools: read, write, edit, ls
+description: Keeps docs/notes.md current with decisions
+tools: read, write, edit
 after-change: noop
 ---
-PURPOSE: Maintain docs/notes.md as durable memory for future work.
-ACT WHEN: The driver trajectory establishes a new project decision or
-constraint that is not already recorded.
-WORK: Read docs/notes.md and add exactly one one-line entry. Edit nothing else.
+PURPOSE: Maintain docs/notes.md as durable project memory.
+ACT WHEN: The trajectory establishes an unrecorded decision or constraint.
+WORK: Add one concise entry and edit nothing else.
 DELIVER: Complete with none; the file is the work product.
 ```
 
-Your heads live in `~/.pi/agent/hydra/`; a repo can ship its own in `.pi/hydra/` (a project head overrides a same-named user head, so a team can specialize your generic heads with ones that know the codebase). Files are re-read at the start of every run, so editing a head tunes the very next observation. `tools:` defaults to everything the agent has; `tools: []` makes a judge-only head; a list narrows to a subset. `after-change: noop|print` gives a writing head deterministic delivery after a successful `write` or `edit`. `autostart: true` puts a head in the active set of every fresh session. The full format and a library of example perspectives are in [`docs/heads.md`](docs/heads.md).
+Heads live in two places:
 
-### Commands
+- `~/.pi/agent/hydra/*.md` — your heads, available everywhere.
+- `.pi/hydra/*.md` — project heads, which override same-named user heads.
+
+Tool permissions are intentionally explicit in their meaning:
+
+- omit `tools:` to grant every standard tool hydra can execute;
+- list names to narrow access, such as `tools: read, grep`;
+- use `tools: []` for a judge-only head with no executable tools.
+
+hydra can execute Pi's standard read, bash, edit, write, grep, find, and ls tools plus its own `hydra` tool. It cannot execute arbitrary MCP or other-extension tools. See [Writing heads](docs/heads.md) for the complete format and examples.
+
+## Decisions
+
+A judge-only head can return several independent findings in one review. hydra groups them by recipient so user-only notes never leak into the agent's context.
+
+| decision | effect |
+|---|---|
+| `print` | Show a note in the TUI; Pi never sees it. |
+| `steer` | Deliver a real user message at Pi's next checkpoint. This is the normal agent-directed route. |
+| `interrupt` | Abort the current run and deliver the finding. This is the emergency cord. |
+| no finding | Deliver nothing; `/hydra-stats` records a noop. |
+
+Acting heads can inspect or change the workspace through their allowed tools before making that decision. The old queue route remains internal for compatibility but is not offered to current heads.
+
+## Heads and subagents solve different problems
+
+| | hydra head | subagent |
+|---|---|---|
+| Purpose | Watch the live trajectory | Perform delegated work |
+| Context | Reuses the driver's provider context | Builds separate context |
+| Timing | Reviews at the driver's checkpoints | Runs on its own clock |
+| Model | Must use the driver's model | May use another model |
+| Direction | Can steer or stop the driver | Returns a result to its parent |
+| Independence | Inherits the driver's framing | Can provide fresher eyes |
+
+Use a head when you want another perspective **during** the work. Use a subagent for isolated implementation, model diversity, or an independent context. They complement each other.
+
+## Commands
 
 | command | what it does |
 |---|---|
-| `/hydra-heads [set\|none]` | no argument opens the picker; an argument sets the active heads declaratively |
-| `/hydra-stats` | cache hit ratio, cost, recent decisions |
-| `/hydra-debug` | dump driver/observation payload pairs for diffing |
+| `/hydra-heads [set\|none]` | Pick or set active heads. |
+| `/hydra-stats` | Show cache hit ratio, cost, and recent decisions. |
+| `/hydra-debug` | Dump driver/observation payload pairs for parity checks. |
 
-The active head set persists per session and survives resume. For headless runs (`pi -p`), seed it with `--hydra-heads quality,security`. An explicit flag beats the saved session set; the saved set beats `autostart`.
+The active set is session state and survives resume and branch navigation. The agent can also add or remove a head through hydra's `manage_heads` tool; real changes print an automatic receipt.
 
-### Decisions
+## What it costs
 
-Judge-only heads (`tools: []`) return one JSON findings array on both providers. Each finding chooses its own delivery; an empty array means nothing warrants feedback. OpenAI receives the raw lens plus a developer envelope, while Anthropic receives one combined prompt. Acting OpenAI heads still call the typed `hydra` tool once with `action: "complete_observation"`; acting Anthropic heads return one compact JSON decision because a native completion call measured substantially slower and more expensive there.
+Cache-backed does not mean free. Each observation pays for a fresh handoff, output, and anything the provider does not read from cache. Total session overhead grows with providers, models, turns, active heads, and output volume; an always-on head can add material cost.
 
-- `print`: a note to you. Renders in the TUI, never enters the agent's context.
-- `steer`: the normal and only agent-directed delivery. It folds in as a real user message at the agent's next checkpoint, whether the finding can wait or not.
-- `interrupt`: the cord. The in-flight run is aborted and the finding opens the next one.
-- `none` (acting completions only): nothing to report. A judge-only head signals silence with an empty findings array instead; `none` is not a valid finding action, and one invalid action makes hydra discard every finding in that response. `/hydra-stats` labels silent outcomes `noop`.
-
-For an enumerated judge response, hydra preserves every message exactly once and groups by recipient: all `print` findings become one user-only note, while all `steer`/`interrupt` findings become one agent message. The agent message interrupts only when at least one of its findings chose `interrupt`; otherwise it steers. A mixed response therefore creates at most two deliveries without leaking a user-only finding into the agent's context. Acting completions require an exactly empty message for `none` and a non-empty message otherwise. Malformed judge output and malformed Anthropic acting output become `noop`; OpenAI rejects malformed typed calls. `after-change` only fixes delivery after a successful `write` or `edit`; it never decides whether the head should act and does nothing on observations without one. The old `queue` route remains implemented for compatibility but is no longer offered in model-facing prompts or schemas; `steer` covers the waitable case, since it already folds in at the agent's next checkpoint.
-
-### The agent manages its own heads
-
-hydra registers one discriminated tool. The agent uses `action: "manage_heads"` with `operation: "add"|"remove"`, one head name, and a short message explaining why the change fits the current trajectory. The head files themselves are ordinary files the agent manages with its ordinary tools: a written head becomes available at the next run or `hydra` tool call (the discovery points), and every change lands as a visible write in the session, auditable and diffable. A workflow can swap heads per phase: design wants devil's-advocate thinking, execution wants quality and security, review wants simplifier.
-
-The same action is available to a head only when its `tools:` allowance includes `hydra` (or is omitted). A real observer-originated set change automatically prints one factual receipt plus the head's explanation; idempotent and failed changes print nothing. Removing itself is terminal, so a foreman can print and leave in one enforced action. Other acting OpenAI observations finish through `complete_observation`; acting Anthropic observations return the corresponding decision as JSON. Judge-only heads use the enumerated contract above.
-
-The tool deliberately stops there. Everything the agent does to its heads is visible and reversible: set changes are announced, head files are plain markdown you can read and `git diff`. Turning hydra off entirely is pi's extension enable/disable, which the agent cannot touch.
-
-## How it works
-
-hydra captures the agent's provider requests byte-for-byte and replays them, with one observation prompt appended, at the moments the agent's own prompt cache commits: when a response begins streaming mid-run, and at run end. Each observation is therefore a cache read of the committed prefix (mid-run observations measured write=0), fresh through the latest tool results, and on Anthropic (and codex in shared mode) the cache stays warm for the agent too. Every mechanism behind that sentence is measured; the measurements live in [`experiments/`](https://github.com/pandysp/pi-hydra/blob/openai-cache-clean/experiments/INDEX.md) and the design in [`docs/architecture.md`](docs/architecture.md).
+The current measured ranges, dated evidence, model coverage, and provider-specific caveats live only in [Providers and measurements](docs/providers.md#economics-and-measurements). `/hydra-stats` reports the same accounting for your session.
 
 ## Limitations
 
-- Two providers for now: Anthropic (Messages API) and OpenAI Codex (ChatGPT backend, GPT-5.6). On codex, set pi's `"transport": "websocket"`: observations then share the driver's cache from the first turn. Under the default `"auto"`, hydra observes in its own cache scope to keep the driver's delta continuation safe, and the first observations pay a cold start ([measured](docs/architecture.md#openai-codex-support)). Anthropic delivers the 97%+ hit ratio; codex measures ~84–87%. Nothing else is verified: hydra targets subscription auth on both providers, and the OpenAI API-key path shares the code but stays disabled unless someone measures it.
-- A head always runs the driver's model. The cache is model-specific, so a head cannot use a stronger or cheaper model than the driver's; that is what subagents are for.
-- A head is not an independent reviewer. It reads the driver's exact context, so it inherits the driver's framing, assumptions, and blind spots. It catches problems while they are cheap, and it does not replace a black-box review of the finished work.
-- A long generation streams to completion unjudged. Decisions form on committed request snapshots, so the cord is pulled between turns, never mid-stream ([Where this is going](#where-this-is-going)).
-- An always-on head adds material, variable session cost ([What it costs](#what-it-costs)); the measured always-on-head trajectories are substantially costlier on OpenAI than on Anthropic. On subscription codex that spend comes out of the same account quota as the agent's own work.
+- **Shared framing:** heads see the driver's context, so they inherit many of its assumptions and blind spots. hydra is continuous review, not independent assurance.
+- **One model:** a head must use the driver's model because the cache is model-specific.
+- **Measured providers only:** unverified provider/API pairs are skipped rather than risk unsafe or full-price replay.
+- **Between-call review:** a single long generation is not judged token by token. Findings act at checkpoints.
+- **Variable overhead:** multiple always-on heads can cost more in aggregate than the driver.
+- **Tool defaults:** a head with omitted `tools:` receives all hydra-supported standard tools; use `tools: []` when review alone is intended.
 
 ## Where this is going
 
-- **Mid-generation interrupts.** Every decision today is formed from a committed request snapshot, so a single long-running LLM call streams to completion unjudged; the cord can only be pulled between turns. Interrupting a runaway generation while it streams would mean reasoning over message deltas, with no cache parity since the content is mid-flight.
-
-If that interests you, issues and PRs are welcome; see [CONTRIBUTING.md](CONTRIBUTING.md). The codebase is small on purpose: seven root modules ([CONTRIBUTING.md](CONTRIBUTING.md) maps them) and an experiments harness that re-verifies the cache mechanism against the live APIs. A full cache-probe run costs under a dollar.
+The main open direction is mid-generation observation. Today hydra judges committed request snapshots, so it can steer between turns but cannot evaluate an unfinished response while it streams. Doing that would require reasoning over partial output without prompt-cache parity.
 
 ## History
 
-hydra began as **andon**, named for Toyota's emergency cord: any worker can stop the line when they spot a defect. The original was a bash and tmux contraption that reverse-engineered Claude Code's prompt pipeline to get cache parity, and its only job was interrupting the agent on urgent findings. The project has since outgrown interrupt-only (heads steer, act, enumerate findings, or stay quiet), and the pi extension replaced all of the reverse engineering with first-class hooks. The original lives in [`archive/`](archive/README.md), including the manufacturing-inspired manifesto that still explains the philosophy.
+hydra began as **andon**, a bash and tmux observer around Claude Code. The pi extension replaced its hand-maintained prompt normalization with first-class provider hooks and Pi's own agent loop. The archived implementation and original manufacturing metaphor live in [`archive/`](archive/README.md).
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,241 +1,167 @@
 # Architecture
 
-How hydra observes a pi session through near-pure cache reads. For the what and why, start with the [root README](../README.md); the empirical basis for everything here is [`../experiments/`](https://github.com/pandysp/pi-hydra/blob/openai-cache-clean/experiments/INDEX.md).
+hydra is a small in-process pi extension. Pi remains the driver: it owns the conversation, model, and primary tool loop. hydra captures the provider context Pi already assembled, appends a specialist handoff for each active head, and routes each reviewed result back into the same session.
+
+```text
+Pi request → capture → append head handoff → cache-backed review → deliver
+```
+
+This document explains the system. Detailed provider behavior, economics, dates, and evidence live in [Providers and measurements](providers.md).
+
+## System flow
+
+1. `before_provider_request` captures the driver's provider payload.
+2. `message_start` schedules a mid-run observation after the first response of a run.
+3. `agent_end` schedules a final observation carrying the last assistant message.
+4. The per-head scheduler runs each active head independently.
+5. The observation engine chooses a provider- and mode-specific handoff.
+6. Judge-only heads make one provider call; acting heads use Pi's own agent loop.
+7. Decisions pass through the delivery ledger and become a note, steer, interrupt, or noop.
+8. Calls, configuration, and delivery receipts are persisted as Pi session entries.
 
 ## Commit-point observation
 
-hydra replays the driver's exact provider payload with an observation handoff appended (the driver: pi's main agent, the one you talk to; the heads watch it). Because the prefix is byte-identical, every observation is a prompt-cache read of the entry the driver itself just wrote. On Anthropic the handoff is the combined user prompt. On OpenAI Codex it is the raw head lens as a user message followed by a developer envelope containing hydra's stable protocol; the higher-priority envelope prevents the observer from continuing the driver's task. Observations fire at the driver's own cache commit points, on two triggers:
+hydra reviews at two lifecycle points.
 
-**Piggyback (mid-run).** When a driver response begins streaming (`message_start`, the moment Anthropic's cache entry becomes readable; commit+0 free rides verified), hydra replays that request's captured payload plus an observation handoff. The driver just paid the cache write, so the observation is a pure cache read, includes the latest assistant message and tool results, and its decision typically lands while the driver's response is still streaming. The run's first response is skipped: the previous run-end observation already reviewed everything before it.
+**Mid-run (`message_start`).** The captured request already contains the conversation through the latest tool results. On Anthropic, response start is the verified point where that request is immediately cache-readable. Codex uses the same lifecycle trigger, but its commit/read timing is looser. The first response of a run is skipped because the previous run-end observation already reviewed the preceding state.
 
-**Run-end (agent_end).** When the driver hands control back to the user, no next request will carry the final assistant message M into the cache, so the observation appends M itself. The observation hands M to its `runAgentLoop` call, and pi-ai's own provider code serializes M: thinking blocks, signatures, surrogate sanitization, parity by construction. On Anthropic, the `onPayload` hook then splices that output onto the captured prefix and moves the driver's message-level cache marker (TTL included) onto M's last markable block (text or tool_use), staying inside the 4-breakpoint budget. The observation carries M either way; the marker turns M from 1.0× fresh input into a 1.25× cache write, a 0.25× premium. The driver's next turn then reads M at 0.1× instead of writing it at 1.25×, saving 1.15×. That is the ~5:1 bet (1.15 against 0.25), and it lands because human latency far exceeds observation TTFT: M's entry is warm long before the next turn needs it. On OpenAI the splice is marker-free; implicit caching breakpoints the latest message server-side. See [OpenAI Codex support](#openai-codex-support).
+**Run end (`agent_end`).** No later driver request has carried the final assistant message yet, so hydra passes that message through Pi's own provider serialization and appends it before the head handoff. This keeps the observation current rather than one assistant message behind.
 
-```
-mid-run:  request N+1 dispatched ─► payload captured
-          response N+1 begins    ─► PIGGYBACK: replay payload + handoff (pure read)
-run end:  agent_end              ─► RUN-END: payload + M(marker) appended
-  ↓
-runAgentLoop(); onPayload splices pi-ai's own serialization onto the captured bytes
-  ↓
-provider completion: enumerated judge JSON / acting typed call or JSON
-  ↓
-apply declared delivery after a successful write/edit
-  ↓
-none      → log internally as noop
-print     → ctx.ui.notify (renders in the TUI, never enters the agent's context)
-queue     → pi.sendMessage({ deliverAs: "followUp" })  [internal compatibility only]
-steer     → pi.sendUserMessage({ deliverAs: "steer" })
-interrupt → ctx.abort() + pi.sendUserMessage({ deliverAs: "followUp" })
+The provider-specific timing and cache consequences are canonical in [Provider lifecycle](providers.md#provider-lifecycle).
+
+## Prompt construction
+
+There is no universal head prompt. A handoff combines two responsibilities:
+
+```text
+head Markdown body       Hydra protocol
+(specialist policy)  +   (tools, completion, delivery)
 ```
 
-Model, tools, and thinking config are identical. The only additions are the observation handoff at the end: one combined user message on Anthropic, or user lens plus developer envelope on OpenAI. Cache hit ratio is determined by the handoff's size relative to the driver context.
+`observationHandoffFor()` chooses one of four paths:
 
-The provider split is measured, not a compatibility guess. A July 2026 A/B used two real heads, two adjacent randomized replicates in every approved model/thinking cell (40 Anthropic and 48 OpenAI runs), then immutable real-trajectory checkpoints. On OpenAI the first developer-envelope treatment cut extra observer turns from 67 to 3 and preserved total-loop cache hit (83.07% versus 83.30%). It raised review-action accuracy from 72.2% to 84.4%; after the generic envelope was tightened so the lens alone controls scope, intervention thresholds, and deduplication, a fresh treatment run reached 98.9% (88/89 API-successful calls) versus 72.2% for the same saved control cases. Two blinded judges preferred that final treatment 62 times versus 15 for control, with 103 ties. On Anthropic the system envelope left accuracy tied at 64.4%, reduced parse validity from 100% to 96.7%, helped Opus but regressed Sonnet, and added 744 ms mean review latency. A treatment that helps one model and hurts another would need a per-model capability gate, which the design rejects (head and envelope semantics stay general), so Anthropic keeps one combined user prompt for every model. Reversing its message order is not an option: the API rejects a content-bearing mid-conversation system message unless it precedes an assistant message or ends the array.
+| | Judge-only | Acting |
+|---|---|---|
+| Anthropic | Combined lens and protocol | Combined acting prompt and JSON completion |
+| OpenAI Codex | User lens plus developer envelope | User lens plus developer envelope and typed completion |
 
-Observations run through a conflating single-slot scheduler, per head: every head has at most one observation in flight and one waiting slot that a newer snapshot overwrites, and an in-flight observation always runs to completion. Staleness is bounded to one cycle because the slot always holds the newest snapshot. The granularity is per head rather than one global batch so an acting head's minutes-long tool loop cannot starve the judging heads, and a head that is busy through a commit point still reviews the newest snapshot the moment it frees up.
+The head file alone defines scope, intervention criteria, and suppression. Hydra's protocol defines mechanism: tool allowance, delivery context, output shape, and completion rules.
+
+## Payload merge
+
+The observation request keeps the driver's captured content prefix and appends a fresh tail containing the final assistant message when needed, the specialist handoff, and any acting-loop turns.
+
+For an Anthropic mid-run observation, the captured prefix remains byte-identical and Hydra appends a fresh handoff. The complete request is therefore longer; it is not itself byte-identical to the driver request. At Anthropic run end and during acting loops, Hydra deliberately relocates the deepest message-level cache marker onto the appended tail while preserving content-prefix parity.
+
+Codex uses an append-only `input` merge and no explicit marker relocation. See [Provider payload mechanics](providers.md#provider-payload-mechanics) for the exact differences.
 
 ## Heads are files
 
-A head is fully defined by one markdown file ([`heads.md`](heads.md) has the format). Discovery reads `~/.pi/agent/hydra` and the nearest ancestor `.pi/hydra`, project shadowing user, fresh at every `agent_start` and every `hydra` tool call; a vanished file prunes its head from the active set with a notice. The active set is the one piece of state not on disk: it persists as `hydra-config` session entries, restored on resume and branch navigation. At session start the precedence is an explicit `--hydra-heads` flag (present intent), then the saved set (recorded intent), then the files' `autostart` markers (the cold-start default, deliberately not persisted so a resumed session re-reads the files). Which delivery a decision carries normally remains the head's choice. Writing heads may additionally declare `after-change: noop|print`; this fixes delivery only after a successful `write` or `edit` and cannot make unwarranted work warranted.
+A head is fully defined by one Markdown file. Discovery reads:
 
-## Cache hit ratio
+- `~/.pi/agent/hydra/*.md` for user heads;
+- the nearest ancestor `.pi/hydra/*.md` for project heads.
 
-| Driver context | Observation prompt | Theoretical hit |
-|---:|---:|---:|
-| 4K | 220 | 94.8% |
-| 10K | 220 | 97.8% |
-| 30K | 220 | 99.3% |
-| 100K | 220 | 99.8% |
+Project heads shadow same-named user heads. Discovery runs at session start, every agent run, and every hydra tool call, so edits affect the next observation. Vanished files are pruned rather than observed with an empty instruction.
 
-The real measurement below is from the earlier turn_end-era architecture; the current commit-point triggers measure the same or better (live e2e on fable/xhigh: 7/7 piggyback observations were pure cache reads, write=0, and every run-end fork wrote exactly M's tokens). On a multi-prompt session (3 prompts, 4 observations):
+The active set is session state. Startup precedence is an explicit `--hydra-heads` flag, then the saved session set, then `autostart` markers for a fresh session. Full authoring behavior belongs in [Writing heads](heads.md).
 
-```
-turn 0 (cold start, 3.5K ctx):  hit 87.79%  read 3552  write 345  input 149
-turn 0 (warm, 7.7K ctx):         hit 98.11%  read 7720  write 0    input 149
-turn 1 (warm, 16.5K ctx):        hit 99.07%  read 16534 write 0    input 156
-turn 0 (warm, 16.7K ctx):        hit 99.12%  read 16741 write 0    input 149
-                                 ─────────────────────────────────────────
-aggregate hit:                   97.92%
-total cost:                      $0.0202 (4 observations)
+## Per-head scheduling
+
+Each head owns one running observation and one waiting slot. A new snapshot replaces the waiting one, so a busy head catches up to the newest state instead of draining an obsolete backlog.
+
+```text
+security: running ──► newest waiting snapshot
+quality:  running independently
+docs:     running independently
 ```
 
-Cold-start observations are bounded by tiny initial context. From roughly 10K of driver context (the table's 97.8% row) every observation hits 97%+, and the session aggregate converges above the 97% target.
-
-## Observation timing
-
-Two measured facts fix the timing (the measurements live in [`../experiments/`](https://github.com/pandysp/pi-hydra/blob/openai-cache-clean/experiments/INDEX.md)):
-
-- A cache entry becomes readable the moment the writing request's response begins (`message_start` ≈ TTFT). Post-commit propagation is indistinguishable from zero; commit+0 free rides verified on haiku and fable, with and without thinking.
-- A response is never cached by the request that produced it. An observation that does not append M itself sees a context that is exactly one assistant message stale.
-
-Hence the two triggers: mid-run observations fire at the driver's own commit (`message_start` of its response), where everything is already cached and fresh through the tool results; run-end observations append M and pay its write once, pre-warming the driver's next turn. No delay or propagation heuristic is needed. The driver's cadence provides the cache-coherent observation points.
-
-M's serialization is parity by construction: the observation hands M to its `runAgentLoop` call, and the `onPayload` hook splices pi-ai's own provider output onto the captured prefix. The fork's bytes match the driver's next request through the exact code path that will produce it, including surrogate sanitization and the dropping of aborted or errored messages. There is no hand-maintained mirror to drift when pi-ai changes.
-
-Selecting M is identity matching. pi constructs the response message about a millisecond before `before_provider_request` fires, so any wall-clock comparison against the capture time is a same-millisecond coin flip that silently drops M on the losing side (measured: -1ms, 0ms, -1ms across three runs). hydra records the response's own timestamp at its `message_start` and attaches M only on an exact match; runs whose final request errored or aborted have no response to match and correctly attach nothing.
-
-Verified end-to-end in June 2026, cross-process (stricter than the normal in-session case, since the session is re-serialized from disk): the piggyback observation was a pure cache read (read 4995, the full committed prefix, write 0); the run-end fork wrote exactly M (342 tok); and the driver's next first request read prefix+M to the token (5337 = 4995 + 342), writing only its new user message (25 tok). Re-verify after pi upgrades with two headless runs. The second run's first `cacheRead` must equal run 1's total (prefix + M), and its `cacheWrite` must be about the new prompt, not about M:
-
-```bash
-# HYDRA_SHUTDOWN_GRACE_MS keeps the headless process alive for the run-end
-# observation (see Limitations & roadmap)
-HYDRA_SHUTDOWN_GRACE_MS=120000 pi -p --session-dir /tmp/v "Explain TCP slow start in 200 words, plain text, no tools."
-HYDRA_SHUTDOWN_GRACE_MS=120000 pi -p -c --session-dir /tmp/v "Thanks. One sentence: what is the congestion window?"
-jq -r 'select(.type=="message" and .message.role=="assistant") | .message.usage | [.cacheRead, .cacheWrite, .output] | @csv' /tmp/v/*.jsonl
-```
-
-## OpenAI Codex support
-
-GPT-5.6 aligned OpenAI's caching economics with Anthropic's (reads 0.1×, writes billed 1.25×, explicit breakpoints, documented 30-minute retention), which lets the same capture-and-replay design apply nearly unchanged. The ChatGPT Codex backend that pi's `openai-codex` provider talks to turned out to obey almost none of the documented platform semantics, so everything below is measured against it directly (gpt-5.6-luna, July 2026). The probes are checked in ([`codex-cache-scoping.mjs`](https://github.com/pandysp/pi-hydra/blob/openai-cache-clean/experiments/attic/codex-cache-scoping.mjs) and [`codex-entitlement.mjs`](https://github.com/pandysp/pi-hydra/blob/openai-cache-clean/experiments/attic/codex-entitlement.mjs), cents of subscription quota); re-run them after pi upgrades or suspicious footer numbers.
-
-**The merge is append-only.** `mergeOpenAIObservationPayload` splices pi-ai's serialization of `[M?, user lens, ...loop turns]` onto the captured `input`, inserts the developer envelope immediately after the lens, and touches nothing else. No marker moves: implicit caching breakpoints the latest message server-side, which is the frontier-advance the Anthropic merge arranges by hand. A marker on M is not even expressible: explicit breakpoints are legal only on input blocks (`input_text`, `input_image`, `input_file`), never on assistant output.
-
-**The OpenAI role split is also an entitlement constraint.** A combined-user tail looks simpler, but after the account's included quota was exhausted, all 24 final-candidate combined-user calls failed with `The usage limit has been reached` and zero usage while their adjacent user-lens-plus-developer-envelope controls succeeded. A minimal alternating probe reproduced the split 2/2 in both orders. Whatever backend routing causes this is outside the extension; keeping the raw lens in user and the protocol in developer is therefore both the higher-quality and the entitlement-safe design.
-
-**Measured backend behavior, and its volatility.** The probes ran on consecutive days and partially disagreed; treat every number here as a dated snapshot, not a constant. Stable across both runs: cache entries behave *session-scoped* in controlled probes (same `prompt_cache_key` from a different session reads nothing; a different key from the same session reads everything), entries become readable within 65 s (a probe at 40 s missed; in full-stack traffic sometimes near-instant), and `cache_write_tokens` is never reported (writes appear free on subscription). Read granularity itself moved: the July 13–14 probes reported 128-token blocks, while the July 24 pi 0.82 causal probe reported 512-token steps. Volatile: entry lifetime was ~2–9 minutes on 2026-07-13 and under ~85 s idle on -14 (never anywhere near the platform's documented 30 minutes); GPT-5.6 refused missing/v4 session ids and the SSE transport outright on -13 (`Model not found gpt-5.6-luna-free-1p-...`, the failure pi-ai's own v4 fallback request id would produce) but accepted all of them on -14. hydra keeps the UUIDv7 id and websocket pin as costless invariants that were required at least once. Full-stack pi traffic also showed occasional cross-session reads of identical content, so treat scoping as multi-signal routing where sharing the session id *guarantees* co-location and anything else is opportunistic. The safety machinery below deliberately depends on none of these numbers: volatility moves the economics (visible in the footer), never the driver's safety.
-
-**Sharing the driver's session is the prize.** Observing under the *driver's* session id means every observation reliably reads the entries the driver itself writes (no cold start, ~87% from a session's first observation), and the run-end write lands where the driver's next turn can find it. It is safe only when the driver sends its full input every turn (pi setting `"transport": "websocket"`, or `"sse"`), and the safety is structural, not just measured: a full-input driver never sends `previous_response_id`, so there is no server-side reference for an observation to evict.
-
-**The fallback is one-way.** Under the default `"auto"`, the driver relies on its websocket *delta continuation*, whose client-side bookkeeping lives in a different pi-ai module instance than the extension's; an observation response under the shared session then evicts the reference server-side and the driver's own next request fails with `Previous response with id 'resp_...' not found` (reproduced 2/2 under `auto`; 0 failures under `websocket`). hydra therefore pins the share decision at the first `agent_start` (the closest an extension gets to the moment the driver was built from the same settings file) and re-resolves the setting *per observation*, because pi's settings selector retargets the live agent mid-session and a cached read would go stale in the unsafe direction. The strategy is monotone: full-input transports observe under the driver's session; the moment any read is a continuation transport, hydra drops to one observer-owned UUIDv7 per extension instance for the rest of the session, never upgrading back (a flip back could resurrect continuation state that shared-mode observations already evicted).
-
-**The tripwire is the backstop.** The fallback is backstopped two ways: measured (zero driver failures across five fallback sessions against an `auto` driver) and actively. If any driver request ends in the continuation-error signature, hydra permanently retreats to its own session for the session and says so, and in-flight acting-head loops wind down at their next turn boundary, converting an unknown backend change from "breaks repeatedly" into "at most one break" (live-fire verified, see [Verifying the tripwire](#verifying-the-tripwire)). One residual race is irreducible client-side and accepted: a settings flip to `"auto"` while a shared observation request is in flight can evict the driver's first post-flip continuation reference; one break at most, which the tripwire then makes final. The delta saves no tokens on this backend (a full-input resend bills its prefix as cache read, measured driver CH ~87% either way), so the `websocket` setting costs the driver upload bandwidth only. The clean fix is upstream: extensions sharing pi's own pi-ai instance would give shared client bookkeeping, which handles the divergence correctly by construction (verified in single-instance reproduction).
-
-**Verified live (July 2026).** Acting heads: a `tools: read` head ran 2-turn tool loops at 84.5%/84.2% first-call parity, decisions annotated, zero errors. Multi-head fan-out: three heads in parallel produced 6 observations at 84.6–85.0% with no connection-limit contention (~$0.012 for the full fan-out on luna). The tripwire, end-to-end: forced sharing against an `auto` driver evicted its continuation, the driver's next request failed with the signature, hydra retreated permanently with the correct notices, and the driver recovered on pi's own retry: one lost request, nothing else. The probe matrix at ~65K tokens: writes readable in under 65 s despite 4× prefill, scoping and key-irrelevance unchanged, entry lifetime still volatile (the ~2-minute control hit at 65K on the same day it missed at 15K).
-
-**Still unverified, named.** pi-ai keeps a per-session SSE-fallback registry that one websocket connect failure can trip permanently: hydra's observations would then run SSE for the rest of the session. The driver is unaffected (separate module instance), but on days the backend refuses SSE for GPT-5.6, every observation fails with a per-observation error until restart. Older codex models (gpt-5.4, gpt-5.5) pass the same gate but their cache economics are unvalidated (visible in the footer if they misbehave). The OpenAI API-key path is out of scope for this project (see below). An Anthropic live re-verification of the `getApiKey` addition waits on an Anthropic login. On subscription codex, observations spend the same account quota as the driver.
-
-**What the numbers mean per provider.** The footer's 97% target is an Anthropic number. On codex, a healthy warm observation reads ~84–87% (measured) and pays the newest turn plus the observation tail as input; `write` stays 0 because the backend doesn't report it. An observation racing the ~1-minute commit window can pay its snapshot as fresh input once (degradation, not failure). The session-level cost reference is the registered production-shaped OpenAI wave of 2026-08-03, six driver runs with two paired observation contracts: ENUM, the shipped enumerate-all-findings judge contract, and MAIN, the single-finding baseline. Across cache-comparable observations (103 of 130 charged calls for MAIN, 108 of 130 for ENUM), MAIN cost $0.0253 per observation and 52.1% of driver cost, while ENUM cost $0.0356 and 77.0%. Charged totals that keep every cache miss, plus the two calls fired after a failed driver turn, raise the ratios to 66.2% and 93.3%. MAIN was cheaper in all six cells. These numbers establish cost only; the quality benchmark is still in progress. See [OPENAI-CAPSTONE-PRODUCER-RESULTS.md](https://github.com/pandysp/pi-hydra/blob/openai-cache-clean/experiments/OPENAI-CAPSTONE-PRODUCER-RESULTS.md). The per-observation shape, from the July 2026 live e2e in shared mode (`transport: "websocket"`, gpt-5.6-luna, judge-only quality head):
-
-```
-turn 1 piggyback:         hit 87.4%  $0.0021   first observation of the session — no cold start
-turn 1 run-end:           hit 86.5%  $0.0015
-turn 2 run-end:           hit 85.7%  $0.0017
-turn 3 piggyback:         hit 84.7%  $0.0018
-turn 3 run-end:           hit 84.4%  $0.0016
-turn 4 run-end:           hit 84.1%  $0.0017
-driver throughout:        CH ~87%, zero errors across every shared-mode run
-```
-
-Byte-parity itself was verified separately on every captured pair of the session: the observation payload minus its appended items reproduces the driver payload byte-for-byte (the recipe below).
-
-**The API-key path (`openai/openai-responses`) shares this serializer but stays gated off** in `observe()` until someone measures it: the platform API documents 30-minute retention, itemized `cache_write_tokens`, and key-based scoping, so both its numbers and its economics should differ from the codex backend in hydra's favor.
+An in-flight observation runs to completion unless lifecycle shutdown aborts it. Scheduling is per head, so a long acting loop cannot starve quick judge-only heads.
 
 ## Acting heads
 
-By default a head may run tool calls before its decision; a head file's `tools:` frontmatter narrows the executable work set, down to `[]` for a judge-only head. Acting heads retain the `hydra` return action; judge-only heads return the enumerated JSON contract directly. The mechanism extends the replay; it does not replace it:
+Tool permissions come from the head file:
 
-**The head owns policy; the envelope owns mechanism.** A robust acting head states a positive contract: purpose, the trajectory condition that warrants action, the work, completion, and delivery. The envelope does not infer those from the head name and contains no docs/tuner/foreman branches. It supplies authority, tool allowance, action semantics, and serialization only. A head whose `tools` list explicitly includes `hydra` also receives the active-set snapshot captured when its observation is scheduled; later `hydra` results supersede it. Heads without that explicit capability receive no state inventory.
+- omitted `tools:` grants all tools hydra can execute;
+- a list narrows execution to that subset;
+- `tools: []` creates a judge-only head.
 
-**Judge completion is one enumerated contract across both providers.** A judge-only head returns `{"findings":[...]}` with one independently labelled entry per finding and an empty list for silence. OpenAI receives the raw lens plus a developer envelope; Anthropic receives one combined prompt. Hydra preserves every message exactly once in at most two recipient batches: `print` findings form one user-only note; `steer` and `interrupt` findings form one agent message, which interrupts only when at least one finding chose it. This keeps the head's user-versus-agent choice instead of promoting unrelated print findings with a more urgent agent finding. Malformed output fails open to `noop` without a recovery call, matching the measured ENUM arm.
+Judge-only heads make one call with no executable tools and may return several findings. Acting heads run through `runAgentLoop` from Pi's agent core, preserving Pi's argument validation, tool errors, execution policy, and cancellation behavior. Every loop iteration still reuses the captured driver prefix.
 
-**Acting completion keeps its two measured transports.** On OpenAI every non-self-removing acting observation must call `hydra` exactly once with `action: "complete_observation"`, a typed delivery, and a message. The call must be alone in its assistant turn, so all fallible work has completed before "done" can be accepted. A malformed call becomes the ordinary pi tool error the model sees and can correct. On Anthropic the acting head instead returns one compact decision object whose `action` is `noop|print|steer|interrupt`. Hydra validates that object, but the model, not a tool call, produces it; malformed output warns and becomes `noop`. The old queue parser and router remain for compatibility, but no prompt or advertised schema offers queue. `manage_heads` and all acting work remain real tools on both providers.
+OpenAI acting heads finish with the typed `hydra` completion action. Anthropic acting heads return a compact validated JSON decision; their actual work and head management still use tools. Provider rationale and measured comparisons live in [Completion channels](providers.md#completion-channels).
 
-Acting heads needed their own A/B, separate from the envelope one in [Commit-point observation](#commit-point-observation), because better review behavior did not guarantee better tool behavior. Across 78 randomized OpenAI pairs on the three codex models (luna, terra, and sol), the final generic design (positive head contracts, typed post-mutation delivery, and capability-scoped state) was correct in 77/78 cases (98.7%) versus 63/78 (80.8%) for the prior design, with no treatment-only family regression: docs 29/30 versus 21/30, tuner 18/18 versus 12/18, foreman 30/30 versus 30/30. It also used fewer calls (201 versus 227), cost less ($0.7499 versus $0.8330), and reduced mean latency (7.10 s versus 7.99 s). A separate frozen foreman screen makes the combined foreman result 45/45 versus 44/45. Earlier variants that encoded scenario-specific exceptions were rejected even when they scored well; the shipped mechanism carries only general semantics.
+## Delivery
 
-The same final head and delivery contracts were then checked through Anthropic's retained combined-user handoff: 42 pairs across Sonnet, Opus, and Fable scored 38/42 versus 31/42, with seven treatment-only wins, zero control-only wins, and four shared misses. The treatment used 112 calls versus 120, cost $0.7285 versus $0.7782, and reduced mean/p95 latency from 7.37/12.01 s to 7.05/11.67 s. Parse validity was 41/42 versus 42/42: one Sonnet treatment made the correct tuning edit but returned malformed JSON; its paired control also failed semantically. That failure remains visible rather than being repaired post hoc.
+Evaluation and delivery are separate:
 
-The final paired OpenAI A/B covered luna, terra, and sol at low through xhigh: 144 review pairs and 96 acting pairs. Typed completion was valid in 144/144 reviews versus 142/144 for JSON and used exactly one call each, eliminating 23 control retry turns. Semantic review accuracy was effectively flat (42/144 versus 40/144), as were mean latency (6.68 versus 6.71 s); the larger tool contract coincided with 16.7% higher cost. Acting accuracy was 95/96 versus 96/96, with one real Terra foreman miss retained. Terminal self-removal stayed 24/24 and fell from two calls and 5.61 s mean to one call and 3.09 s. The complete KPI table and the symmetric correction of one evaluator synonym are in the [experiment log](https://github.com/pandysp/pi-hydra/blob/openai-cache-clean/experiments/README.md#enforceable-completion-ab-july-2026).
+- `print` renders a user-only TUI note;
+- `steer` sends a real user message at the driver's next checkpoint;
+- `interrupt` aborts the current run and delivers the finding;
+- silence is persisted as a noop.
 
-**Post-mutation delivery is deterministic.** `after-change: noop` says a successful write/edit is the complete work product and requires a `none` completion; `after-change: print` requires a non-empty printed note. OpenAI rejects a conflicting completion as a tool error. Anthropic normalizes its returned decision to the declaration because its completion transport cannot enforce the branch before return. The field requires omitted `tools` or a list containing `write` or `edit`; absent metadata preserves model-chosen delivery. Mutations hidden inside bash are deliberately outside the contract.
+Judge findings are grouped into at most one user-only batch and one agent-directed batch. An interrupt based on a stale snapshot is demoted to steer: one turn of delay is safer than aborting newer work from an old judgment.
 
-**Head management carries its own receipt.** `manage_heads` takes an idempotent add/remove operation, one head, and a required explanation. When an observer actually changes the set, the runtime prints `Added|Removed <head>` plus that explanation immediately; failed and idempotent calls print nothing. The driver sees its own tool result and gets no duplicate notification. Successful self-removal is inherently terminal, so it prints and exits in one call. Removing or adding another head is followed by the ordinary completion action. These rules are caller- and state-based, not foreman-specific.
+A delivery ledger tracks pending and successful messages so heads receive factual context about what has already reached the driver. The old queue route remains internal for compatibility but is not offered in current prompts or schemas.
 
-**Acting loops are pi's own.** Every acting observation runs `runAgentLoop` from pi-agent-core (a first-class extension import; the loader aliases it in both bundle modes) rather than a hand-rolled imitation: argument validation, tool errors, parallel-vs-sequential execution policy, and abort discipline stay pi's code and evolve with it. Judge-only heads make one direct provider call with no executable tools. The same reuse approach applies to M's serialization.
+## State and observability
 
-**Every loop call replays the captured prefix.** The loop's own built context is discarded by the `onPayload` merge, so iteration N's request is the byte-true driver prefix plus the observation tail (`[M?, handoff, turn 1, results 1, ..., turn N-1]`). The driver prefix stays a pure cache read on every iteration; measured live, read stayed at the full committed prefix while only tail content was written.
+hydra has no external database. It stores three custom entry types in Pi's session log:
 
-**Tool parity comes from the replay itself.** The replayed prefix carries the driver's active tool schemas byte-for-byte. Acting observations execute the seven standard tools (constructed from pi's exported factories at the driver's cwd), filtered down to the head file's `tools:` list when one is given, plus hydra's shared tool. Inside that tool, `complete_observation` is the acting return channel while `manage_heads` requires omitted tools or an explicit `hydra` allowance. Judge-only heads execute no tools despite seeing the cached schemas. A call outside an acting head's allowance, or to anything hydra cannot execute (another extension's tool, MCP), gets an error result and the head proceeds. write/edit serialize same-file mutations through pi's process-wide queue, shared with the driver because the loader aliases pi-coding-agent to its bundled instance.
+- `hydra-config` — the active head set;
+- `hydra-call` — observation usage, action, timing, and tools;
+- `hydra-delivery` — successful delivery receipts.
 
-**The cache marker advances with the loop.** Cache writes happen only at explicit breakpoints, the budget is four per request, and the driver's payload already spends all four, so the merge only ever moves the deepest message-level marker: onto M for a run-end fork's first call (the pre-warm bet, unchanged), then onto the tail's last markable block once loop turns exist. Each loop turn is written once (plain ephemeral, deliberately without the driver's TTL: the next iteration is seconds away) and read thereafter, instead of re-paid as input every iteration. The prefix+M entry from the first call keeps serving the driver. Anthropic's serving stack was also observed auto-extending entries to the last assistant block on this traffic class without any marker; the explicit advance reproduces those economics within documented semantics instead of relying on observed but undocumented behavior.
+Branch navigation rebuilds this state from the selected session branch. `/hydra-stats` and the footer use the same persisted calls. `/hydra-debug` dumps captured and merged payload pairs for manual parity verification.
 
-**Loops are guarded.** There is no cost ceiling; the only bound is a correctness guard: a loop without a valid completion after 25 model turns is wound down as a `noop` with a warning, and externally removing the head from the active set mid-loop winds it down at the next turn boundary. Completion and successful self-removal stop at that same boundary; neither spends a grace turn. Stats record one `hydra-call` per observation with usage summed across iterations; the hit ratio is taken from the first call alone, since it is the replay-parity signal and later iterations legitimately pay the tail as fresh input.
+## Cache hit ratio
 
-**The observer owns its provider session.** pi cleans provider resources for the driver's session on shutdown. OpenAI observations may deliberately fall back to hydra's separate session id when sharing would endanger delta continuation, so hydra releases that session itself after winding down its heads. Otherwise a completed headless run remains alive until the cached WebSocket's idle TTL expires.
+Detailed hit-rate tables, session costs, measurement dates, and interpretation are maintained in [Economics and measurements](providers.md#economics-and-measurements). The architectural point is narrower: an observation pays for its fresh tail while reusing as much of the captured driver prefix as the provider makes cache-readable.
 
-**File writes are announced.** Every successful write/edit queues a one-line `hydra-feedback` note (`[docs] wrote docs/notes.md`) so the driver is never surprised by files changing under it. The note records provenance for the driver; `after-change: print`, when present, separately controls the user's post-mutation notice. Writes inside the head's bash commands are invisible to both; the authoring guidance in [`heads.md`](heads.md) says to keep bash read-only mid-run.
+## Observation timing
 
-**Decisions from stale snapshots cannot pull the cord.** An acting head can finish its loop minutes after its snapshot was captured. If the driver has moved on to a newer request, an `interrupt` decision demotes to `steer`: a wrong demotion costs one turn of latency, while a wrong abort destroys in-flight work.
+The lifecycle summary is in [Commit-point observation](#commit-point-observation). Exact timing probes, run-end accounting, and re-verification history are in [Provider lifecycle](providers.md#provider-lifecycle).
+
+## OpenAI Codex support
+
+Codex shares the architecture above but has different handoff, session, transport, and cache behavior. In brief: full-input transports may safely share the driver's provider session; continuation transports make hydra fall back monotonically to its own session; a continuation-error tripwire is the final backstop. The complete and canonical behavior is in [OpenAI Codex](providers.md#openai-codex).
 
 ## Limitations & roadmap
 
-**Two providers.** Cache-parity replay is validated on Anthropic's Messages API (97%+ hit ratio) and on the OpenAI Codex backend for GPT-5.6 (~84–87%, no cold start with pi's `"transport": "websocket"`; observer-scoped fallback otherwise, see [OpenAI Codex support](#openai-codex-support)). Everything else (the OpenAI API-key path included) skips observation with a one-time warning until someone measures it; the gate is per provider/API pair in `observe()`.
+- Only measured provider/API pairs observe; others warn and skip.
+- Heads use the driver's model and inherit its framing.
+- Long-running head tools cannot always be hard-aborted mid-execution.
+- Headless shutdown may need a longer `HYDRA_SHUTDOWN_GRACE_MS` for run-end observations.
+- Decisions judge committed snapshots, not partial generations.
+- Multi-head fan-out favors low feedback latency over coordinating every run-end cache write.
 
-**Acting heads cannot be hard-aborted mid-tool.** The lifecycle abort signal reaches the loop at turn boundaries and tool executions receive it, but a long-running bash command started by a head runs to completion on shutdown grace expiry. A known limitation, accepted for now.
-
-**Cold-start observation is below 97%.** The first observation in a fresh session has a small driver context that the observation prompt nearly equals in size. Accepted; the metric converges fast once any history exists.
-
-**Headless (`pi -p`) may truncate the run-end observation.** The process exits shortly after `agent_end`; `session_shutdown` awaits the in-flight observation up to 5s, which slow models (fable/xhigh: 10s+) can exceed. Raise via `HYDRA_SHUTDOWN_GRACE_MS` for headless use (`0` means exit without waiting). Interactive mode is unaffected; the observation completes while you read the response.
-
-**Multi-head fan-out is latency-first.** The active head set fans out one observation per head, in parallel, per trigger. Mid-run this is free beyond the prompts, since every head is a pure cache read of the same committed prefix. At run-end the markered forks race and each pays M's write (~$0.01–0.02 per head on fable, measured); the experiments README documents a message_start-coordination pattern that would let followers free-ride on the first fork's write, deliberately not implemented because the contended amount stays a single-digit percent of observation spend and feedback latency is the product metric.
-
-**Decisions judge committed snapshots, not in-flight output.** Interrupt does cancel: an `interrupt` decision calls `ctx.abort()` on the in-flight run and the finding opens the next one, matching the archived bash version's Escape-then-inject behavior. Steer is the softer rung: the message waits for the current turn's tool calls to finish, then lands between turns of the same run, and the piggyback timing means decisions often arrive while a response is still streaming, in time for the very next turn boundary. What remains future work is judging *partial* output: every decision is formed from a committed request snapshot, so a single long-running LLM call is never evaluated mid-generation. That would require reasoning over `message_update` deltas, with no cache parity since the content is mid-flight.
+Provider-specific limits and evidence are in [Provider limits](providers.md#provider-limits). Mid-generation observation remains future work because partial output has no cache-parity prefix.
 
 ## Module map
 
-There is no build step; pi loads `.ts` via [jiti](https://github.com/unjs/jiti). `index.ts` holds the pi wiring (events, commands, rendering) and the observation engine; `heads.ts` holds the head registry (discovery, shadowing, the active set); `scheduler.ts` holds the conflating per-head scheduler; `stats.ts` holds the observation log and the session-entry parsing; `protocol.ts` holds the hydra tool's wire contract; `delivery.ts` holds the delivery ledger (tests in `delivery.test.ts`); `utils.ts` holds the shared types and the remaining pure logic (decision parsing, payload merge) with tests in `utils.test.ts`. Setup, checks, and the delivery smoke test are in [CONTRIBUTING.md](../CONTRIBUTING.md).
+There is no build step; Pi loads the TypeScript through jiti.
+
+| Module | Responsibility |
+|---|---|
+| `index.ts` | Pi hooks, observation engine, commands, and UI wiring |
+| `heads.ts` | Discovery, shadowing, and active-set registry |
+| `scheduler.ts` | Conflating per-head scheduler |
+| `stats.ts` | Observation log and session-entry parsing |
+| `protocol.ts` | Hydra tool wire contract |
+| `delivery.ts` | Delivery ledger and routing |
+| `utils.ts` | Shared types and pure prompt, parsing, guard, and payload logic |
+
+Setup and checks are in [CONTRIBUTING.md](../CONTRIBUTING.md).
 
 ## Verifying cache parity
 
-```bash
-# In an active pi session running hydra:
-/hydra-debug        # toggles dumping
-# do some work
-/hydra-debug        # toggles off
-# inspect (filenames carry timestamp, head, and sequence):
-ls /tmp/hydra-debug-*/
-# An Anthropic piggyback pair differs only by the combined observation prompt; dropping it
-# from the observation payload must reproduce the driver payload byte-for-byte:
-jq -S '.' <driver.json> > /tmp/drv.json
-jq -S 'del(.messages[-1])' <observation.json> > /tmp/obs.json
-diff /tmp/drv.json /tmp/obs.json   # expected: empty
-# A run-end fork additionally appends M and moves the message-level cache
-# marker onto it, so drop both tail messages and the markers before diffing:
-jq -S 'walk(if type == "object" then del(.cache_control) else . end)' <driver.json> > /tmp/drv.json
-jq -S 'del(.messages[-2:]) | walk(if type == "object" then del(.cache_control) else . end)' <observation.json> > /tmp/obs.json
-diff /tmp/drv.json /tmp/obs.json   # expected: empty
+Use `/hydra-debug` to dump driver/observation pairs. A mid-run Anthropic pair should match after removing the appended handoff. A run-end pair additionally carries the final assistant message and deliberate marker relocation, so compare content after removing the tail and cache markers. A Codex pair should match after truncating the observation `input` to the driver's input length.
 
-# OpenAI pairs are input-shaped and marker-free; the observation must be the
-# driver payload with items appended (two handoff items for piggyback; M may
-# serialize to several, so truncate by driver length instead of a fixed count):
-N=$(jq '.input | length' <driver.json>)
-jq -S '.' <driver.json> > /tmp/drv.json
-jq -S --argjson n "$N" '.input |= .[:$n]' <observation.json> > /tmp/obs.json
-diff /tmp/drv.json /tmp/obs.json   # expected: empty
-```
+Exact commands and expected provider accounting live in [Verification procedures](providers.md#verification-procedures).
 
 ## Verifying the tripwire
 
-The `agent_end` tripwire is the last line of defense; it can be fired for
-real in a throwaway session. `HYDRA_UNSAFE_FORCE_SHARE=1` skips the
-transport leg of the share gate (never the monotone state or the tripwire
-itself), so observations share the driver's session while the driver runs
-its default `"auto"` delta continuation, recreating the exact eviction the
-gate exists to prevent. Never set it outside a throwaway session.
-
-```bash
-cd /tmp/scratch-project
-HYDRA_UNSAFE_FORCE_SHARE=1 pi --model openai-codex/gpt-5.6-luna
-# turn 1: observations fire under the driver's session
-# turn 2: the driver's delta request fails "Previous response ... not
-#         found", the tripwire notice appears, pi's retry recovers the turn
-# turn 3+: observations run in their own cache scope; the fallback warning
-#         names the tripwire as the cause
-```
-
-Verified July 2026: eviction, signature match, permanent retreat, and
-driver recovery all observed live; the driver lost one retried request and
-nothing else.
+The unsafe live-fire procedure is maintained in [Verifying the Codex tripwire](providers.md#verifying-the-codex-tripwire). It intentionally breaks one request in a throwaway continuation session; never use it in real work.
 
 ## Compared to the archived andon (bash) version
 
-hydra began as [andon](../archive/README.md), a bash and tmux contraption around Claude Code. The design deltas:
-
-| | andon (bash, archived) | pi-hydra |
-|---|---|---|
-| Cache parity | 8 normalization rules in `andon-cache-fix.mjs` patching `globalThis.fetch` | byte-true replay via `before_provider_request` capture + `onPayload` override on the observation's own provider call |
-| Driver inheritance | `claude --resume <id> --fork-session --print` subprocess | `runAgentLoop` call from inside the driver process |
-| Observation state | JSON file in `~/.local/state/andon-observer/` | session custom entries via `pi.appendEntry("hydra-call", ...)` |
-| Delivery | `tmux send-keys` | `pi.sendMessage` / `pi.sendUserMessage` |
-| Polling | JSONL mtime watch loop | driver commit events (`message_start`) + `agent_end` |
-| Self-feedback prevention | `recent_decisions` injected into prompt (caused hallucination loops) | factual delivery state from the ledger in the prompt (the head decides); pending feedback becomes part of the replayed context by design, since the head sees exactly what the driver sees |
-| Status display | none / external log | TUI footer with live hit ratio + cost |
+The archived andon observer reconstructed Claude Code context through subprocesses, normalization rules, polling, and tmux delivery. pi-hydra instead captures provider payloads through a first-class hook, reuses Pi's own agent loop and serializer, responds to lifecycle events, persists facts in Pi's session log, and delivers through Pi APIs. The archive remains in [`archive/`](../archive/README.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,9 +1,9 @@
 # Architecture
 
-hydra is a small in-process pi extension. Pi remains the driver: it owns the conversation, model, and primary tool loop. hydra captures the provider context Pi already assembled, appends a specialist handoff for each active head, and routes each reviewed result back into the same session.
+hydra is a small in-process pi extension. Pi remains the driver: it owns the conversation, model, and primary tool loop. hydra captures the provider context Pi already assembled and appends a specialist handoff for each active head. It records each accepted observation call in Pi's session; feedback is then shown only to the user, delivered to the driver, or withheld according to the decision.
 
 ```text
-Pi request → capture → append head handoff → cache-backed review → deliver
+Pi request → capture → append head handoff → cache-reusing review where available → deliver
 ```
 
 This document explains the system. Detailed provider behavior, economics, dates, and evidence live in [Providers and measurements](providers.md).
@@ -16,14 +16,14 @@ This document explains the system. Detailed provider behavior, economics, dates,
 4. The per-head scheduler runs each active head independently.
 5. The observation engine chooses a provider- and mode-specific handoff.
 6. Judge-only heads make one provider call; acting heads use Pi's own agent loop.
-7. Decisions pass through the delivery ledger and become a note, steer, interrupt, or noop.
+7. Decisions pass through the delivery layer and become a user-only note, driver-directed steer or interrupt, or noop.
 8. Calls, configuration, and delivery receipts are persisted as Pi session entries.
 
 ## Commit-point observation
 
 hydra reviews at two lifecycle points.
 
-**Mid-run (`message_start`).** The captured request already contains the conversation through the latest tool results. On Anthropic, response start is the verified point where that request is immediately cache-readable. Codex uses the same lifecycle trigger, but its commit/read timing is looser. The first response of a run is skipped because the previous run-end observation already reviewed the preceding state.
+**Mid-run (`message_start`).** The captured request already contains the conversation through the latest tool results. On Anthropic, response start is the verified point where that request is immediately cache-readable. Codex uses the same lifecycle trigger, but its commit/read timing is looser. The first response of every run is skipped unconditionally; on later runs the preceding state was already reviewed at the previous run end, while a fresh session still receives its first review at an eligible later snapshot or run end.
 
 **Run end (`agent_end`).** No later driver request has carried the final assistant message yet, so hydra passes that message through Pi's own provider serialization and appends it before the head handoff. This keeps the observation current rather than one assistant message behind.
 
@@ -38,7 +38,7 @@ head Markdown body       Hydra protocol
 (specialist policy)  +   (tools, completion, delivery)
 ```
 
-`observationHandoffFor()` chooses one of four paths:
+`observationHandoffFor()` chooses one of four paths for product heads (hidden diagnostic heads use a fixed test prompt):
 
 | | Judge-only | Acting |
 |---|---|---|
@@ -62,7 +62,7 @@ A head is fully defined by one Markdown file. Discovery reads:
 - `~/.pi/agent/hydra/*.md` for user heads;
 - the nearest ancestor `.pi/hydra/*.md` for project heads.
 
-Project heads shadow same-named user heads. Discovery runs at session start, every agent run, and every hydra tool call, so edits affect the next observation. Vanished files are pruned rather than observed with an empty instruction.
+Project heads shadow same-named user heads. Discovery runs at session start, every agent run, and every hydra tool call. Changes discovered at one of those points affect observations scheduled afterward; vanished files are pruned rather than observed with an empty instruction.
 
 The active set is session state. Startup precedence is an explicit `--hydra-heads` flag, then the saved session set, then `autostart` markers for a fresh session. Full authoring behavior belongs in [Writing heads](heads.md).
 
@@ -76,7 +76,7 @@ quality:  running independently
 docs:     running independently
 ```
 
-An in-flight observation runs to completion unless lifecycle shutdown aborts it. Scheduling is per head, so a long acting loop cannot starve quick judge-only heads.
+An in-flight observation runs to completion unless lifecycle shutdown aborts it. Scheduling is per head, so a long acting loop does not occupy another head's scheduler lane.
 
 ## Acting heads
 
@@ -86,18 +86,18 @@ Tool permissions come from the head file:
 - a list narrows execution to that subset;
 - `tools: []` creates a judge-only head.
 
-Judge-only heads make one call with no executable tools and may return several findings. Acting heads run through `runAgentLoop` from Pi's agent core, preserving Pi's argument validation, tool errors, execution policy, and cancellation behavior. Every loop iteration still reuses the captured driver prefix.
+Judge-only heads make one call with no executable tools and may return several findings. Acting heads run through `runAgentLoop` from Pi's agent core, preserving Pi's argument validation, tool errors, execution policy, and cancellation behavior. Every loop iteration still replays the captured driver prefix; whether that replay is a cache hit remains provider-dependent.
 
-OpenAI acting heads finish with the typed `hydra` completion action. Anthropic acting heads return a compact validated JSON decision; their actual work and head management still use tools. Provider rationale and measured comparisons live in [Completion channels](providers.md#completion-channels).
+OpenAI acting heads normally finish with the typed `hydra` completion action; successful self-removal is terminal without a second call. Anthropic acting heads return a compact validated JSON decision; their actual work and head management still use tools. Provider rationale and measured comparisons live in [Completion channels](providers.md#completion-channels).
 
 ## Delivery
 
 Evaluation and delivery are separate:
 
-- `print` renders a user-only TUI note;
+- `print` renders a user-only TUI note in interactive mode and never enters the driver's context;
 - `steer` sends a real user message at the driver's next checkpoint;
-- `interrupt` aborts the current run and delivers the finding;
-- silence is persisted as a noop.
+- `interrupt` aborts an active run and delivers the finding; when idle, it simply starts the next run with that message;
+- a valid quiet decision is persisted as a noop.
 
 Judge findings are grouped into at most one user-only batch and one agent-directed batch. An interrupt based on a stale snapshot is demoted to steer: one turn of delay is safer than aborting newer work from an old judgment.
 
@@ -107,7 +107,7 @@ A delivery ledger tracks pending and successful messages so heads receive factua
 
 hydra has no external database. It stores three custom entry types in Pi's session log:
 
-- `hydra-config` — the active head set;
+- `hydra-config` — explicitly saved active-head changes (autostart alone is not persisted);
 - `hydra-call` — observation usage, action, timing, and tools;
 - `hydra-delivery` — successful delivery receipts.
 
@@ -131,7 +131,7 @@ Codex shares the architecture above but has different handoff, session, transpor
 - Heads use the driver's model and inherit its framing.
 - Long-running head tools cannot always be hard-aborted mid-execution.
 - Headless shutdown may need a longer `HYDRA_SHUTDOWN_GRACE_MS` for run-end observations.
-- Decisions judge committed snapshots, not partial generations.
+- Decisions judge complete captured requests, not partial generations.
 - Multi-head fan-out favors low feedback latency over coordinating every run-end cache write.
 
 Provider-specific limits and evidence are in [Provider limits](providers.md#provider-limits). Mid-generation observation remains future work because partial output has no cache-parity prefix.

--- a/docs/claims.json
+++ b/docs/claims.json
@@ -1,0 +1,169 @@
+{
+  "description": "Joint baselines bind each public behavior claim to narrow code authorities and one canonical documentation section. Update only after reviewing both sides together.",
+  "claims": [
+    {
+      "id": "supported-providers",
+      "code": [
+        {
+          "path": "index.ts",
+          "start": "const anthropic = model.provider === \"anthropic\"",
+          "end": "// At the end of a run"
+        }
+      ],
+      "doc": {
+        "path": "docs/providers.md",
+        "fragment": "supported-provider-boundary"
+      },
+      "baseline": {
+        "codeHash": "279dcda52336786f9cc6c2897dac232cd4f11d0f261b5a021be928e02aa323ef",
+        "docHash": "f024609af30849f8c5b9267bc015d89e89be1ff3810eff41419d7234f8df4927"
+      }
+    },
+    {
+      "id": "observation-triggers",
+      "code": [
+        {
+          "path": "index.ts",
+          "start": "pi.on(\"before_provider_request\"",
+          "end": "pi.on(\"session_shutdown\""
+        }
+      ],
+      "doc": {
+        "path": "docs/architecture.md",
+        "fragment": "commit-point-observation"
+      },
+      "baseline": {
+        "codeHash": "2806ed5c4fe07fccf02cd67b7aa5f9f69940197e98551255eb617ebdae729d48",
+        "docHash": "3bd92e1cdf97a7983c6e7466375084686036863b45e2b3503ec03c85c5e8b05c"
+      }
+    },
+    {
+      "id": "tool-defaults",
+      "code": [
+        {
+          "path": "heads.ts",
+          "start": "headTools(name: string)",
+          "end": "// Records the last set"
+        },
+        {
+          "path": "utils.ts",
+          "start": "export function headActs",
+          "end": "/**\n * Whether the head's instruction"
+        }
+      ],
+      "doc": {
+        "path": "docs/heads.md",
+        "fragment": "tools-acting-heads"
+      },
+      "baseline": {
+        "codeHash": "67e0669796d37b507e71ad1d7d91617c62dccc29a1416c7b3ce9bc04c1e22ff1",
+        "docHash": "b5e9ccc80f59c55f60268f19f7f6ccfebe27fb23e5c66eec26dbdae33276c97c"
+      }
+    },
+    {
+      "id": "prompt-variants",
+      "code": [
+        {
+          "path": "index.ts",
+          "start": "function observationHandoffFor(",
+          "end": "// The exact request the driver last sent"
+        }
+      ],
+      "doc": {
+        "path": "docs/architecture.md",
+        "fragment": "prompt-construction"
+      },
+      "baseline": {
+        "codeHash": "96a250926e5df05369f3849c2dcd528310c4b430c4c2a458c43844af7ccfe4fb",
+        "docHash": "10bcf5cd7330fd912b53edc81649948f07d3793ccf9cefae76870a06fa7bf420"
+      }
+    },
+    {
+      "id": "scheduler-semantics",
+      "code": [
+        {
+          "path": "scheduler.ts",
+          "start": "export class HeadScheduler",
+          "end": null
+        }
+      ],
+      "doc": {
+        "path": "docs/architecture.md",
+        "fragment": "per-head-scheduling"
+      },
+      "baseline": {
+        "codeHash": "78cef2181dfc55aeecb1db477b08d9914cb65b4775ae97439dc34f423c80104d",
+        "docHash": "8712112c8b791826a75b919260b15455813062044dc0021fd9e6ae197e5f08e6"
+      }
+    },
+    {
+      "id": "delivery-actions",
+      "code": [
+        {
+          "path": "protocol.ts",
+          "start": "export const hydraToolParameters",
+          "end": "export interface ManageHeadsParams"
+        },
+        {
+          "path": "delivery.ts",
+          "start": "export function routeFeedback(",
+          "end": null
+        }
+      ],
+      "doc": {
+        "path": "docs/architecture.md",
+        "fragment": "delivery"
+      },
+      "baseline": {
+        "codeHash": "0e225e707839559ae322aa0354f8c20a6abf61e9ec8849cb4f327d132738c1e9",
+        "docHash": "6a961d1f59eacb6fa8a03fff13646ddfe84c1f27009c30560040723458f79ac4"
+      }
+    },
+    {
+      "id": "head-precedence",
+      "code": [
+        {
+          "path": "heads.ts",
+          "start": "discover(gateway: HeadRegistryGateway",
+          "end": "exists(name: string)"
+        },
+        {
+          "path": "index.ts",
+          "start": "pi.on(\"session_start\"",
+          "end": "pi.on(\"session_tree\""
+        }
+      ],
+      "doc": {
+        "path": "docs/architecture.md",
+        "fragment": "heads-are-files"
+      },
+      "baseline": {
+        "codeHash": "3d243de90942b5e964ecf7fed6457235eb4e257bcb30094903486dbc507f3f70",
+        "docHash": "885716e10ec77195d00f8fc20d4e861aed535fa137138560b6c7bb1faf2c1ccd"
+      }
+    },
+    {
+      "id": "persisted-state",
+      "code": [
+        {
+          "path": "stats.ts",
+          "start": "export function parseBranchEntries(",
+          "end": null
+        },
+        {
+          "path": "index.ts",
+          "start": "function restoreFromBranch(",
+          "end": "// One observation's outcome"
+        }
+      ],
+      "doc": {
+        "path": "docs/architecture.md",
+        "fragment": "state-and-observability"
+      },
+      "baseline": {
+        "codeHash": "78e191888369414aefdec5dccde366853a0425a944bda571cd3536e603598b35",
+        "docHash": "98d9aacd194070bc28904ae93255e62c3fc3d084c89c2053a710828677431ffb"
+      }
+    }
+  ]
+}

--- a/docs/claims.json
+++ b/docs/claims.json
@@ -34,7 +34,7 @@
       },
       "baseline": {
         "codeHash": "2806ed5c4fe07fccf02cd67b7aa5f9f69940197e98551255eb617ebdae729d48",
-        "docHash": "3bd92e1cdf97a7983c6e7466375084686036863b45e2b3503ec03c85c5e8b05c"
+        "docHash": "04b157f3f0a9fa9ae01ff177a7cacbb6375894ab0f4504ab074a2499489e4999"
       }
     },
     {
@@ -75,7 +75,7 @@
       },
       "baseline": {
         "codeHash": "96a250926e5df05369f3849c2dcd528310c4b430c4c2a458c43844af7ccfe4fb",
-        "docHash": "10bcf5cd7330fd912b53edc81649948f07d3793ccf9cefae76870a06fa7bf420"
+        "docHash": "78d6ab75500a567df183cc03ab2e0a46f66eccdb36172b357a628b29d70356e6"
       }
     },
     {
@@ -93,7 +93,7 @@
       },
       "baseline": {
         "codeHash": "78cef2181dfc55aeecb1db477b08d9914cb65b4775ae97439dc34f423c80104d",
-        "docHash": "8712112c8b791826a75b919260b15455813062044dc0021fd9e6ae197e5f08e6"
+        "docHash": "3941be2a5021516f9391169e1bd82ed2407e909dfb119002198888b8c22fecce"
       }
     },
     {
@@ -116,7 +116,7 @@
       },
       "baseline": {
         "codeHash": "0e225e707839559ae322aa0354f8c20a6abf61e9ec8849cb4f327d132738c1e9",
-        "docHash": "6a961d1f59eacb6fa8a03fff13646ddfe84c1f27009c30560040723458f79ac4"
+        "docHash": "338a4bf1820c65b8200966d985f1b5cd09c92c824f4b878380823c4b69791301"
       }
     },
     {
@@ -139,7 +139,7 @@
       },
       "baseline": {
         "codeHash": "3d243de90942b5e964ecf7fed6457235eb4e257bcb30094903486dbc507f3f70",
-        "docHash": "885716e10ec77195d00f8fc20d4e861aed535fa137138560b6c7bb1faf2c1ccd"
+        "docHash": "12a15a36e3c3552bfdb947f92c05447f79ab8e232d3242246f2c6b38f71080f7"
       }
     },
     {
@@ -162,7 +162,7 @@
       },
       "baseline": {
         "codeHash": "78e191888369414aefdec5dccde366853a0425a944bda571cd3536e603598b35",
-        "docHash": "98d9aacd194070bc28904ae93255e62c3fc3d084c89c2053a710828677431ffb"
+        "docHash": "cd76668426ce9a2d24ba23d15bb2107349ea4c66276019b5eb317d4fa7f215f2"
       }
     }
   ]

--- a/docs/heads.md
+++ b/docs/heads.md
@@ -1,6 +1,6 @@
 # Heads
 
-A head watches with its own perspective: it sees exactly what the agent sees, judges every step, and reports findings through print, steer, or interrupt (or stays quiet). A head is fully defined by one markdown file. The file carries the head's identity, its capabilities, and its instruction; there is nothing else to configure.
+A product head watches with its own perspective: it reviews complete captured requests from the agent's provider trajectory and reports findings through print, steer, or interrupt (or stays quiet). A busy head keeps only the newest waiting snapshot, so superseded intermediate snapshots may be skipped. One Markdown file carries the head's identity, capabilities, and instruction; activation is separate session state.
 
 ## Head files
 
@@ -28,7 +28,7 @@ Frontmatter keys:
 
 The filename is only storage: identity comes from `name`. By convention, name the file after the head.
 
-There is no `model` key and there cannot be one: a head replays the agent's prompt cache, and the cache is model-specific. Every head runs on the agent's model. That is the constraint that makes the replay a cache read rather than a context rebuild, and it is why a head cannot be given a stronger model than the driver's.
+There is no supported `model` key: a head replays the agent's provider context, and prompt caches are model-specific. Every head runs on the agent's model. Matching the model is required for cache reuse—though provider timing and session routing still determine the actual hit—and is why a head cannot be assigned a stronger model than the driver's.
 
 ## Where heads live
 
@@ -37,9 +37,9 @@ There is no `model` key and there cannot be one: a head replays the agent's prom
 
 A project head with the same name as a user head wins, like project agents and presets elsewhere in pi, so a repo can replace your generic `quality` with one that knows the codebase conventions. Project files are repo-controlled prompts and run under the same consent as everything else in `.pi/`: pi's folder trust. When hydra loads project heads it says so in the TUI, and once more when a project head shadows one of yours.
 
-Head files are re-read at the start of every agent run and on every `hydra` tool call, so edits apply to the next observation without a reload: when a head flags too much or too little, tune the file and the very next run uses the tuned head. Duplicate names within one directory warn and keep the first file. If a file behind an active head disappears, the head is dropped from the active set with a notice, never silently.
+Head files are re-read at the start of every agent run and on every `hydra` tool call. Changes apply to observations scheduled after that discovery point without reloading Pi: tune a noisy head before the next run, or follow a write with a `hydra` call when it must take effect during the current run. Duplicate names within one directory warn and keep the first file. If a file behind an active head disappears, the head is dropped from the active set with a notice, never silently.
 
-There are no built-in heads. The [`heads/`](../heads) directory in this repo holds ready-to-use examples (the quality, security, simplifier, and api-design reviewers, plus the foreman and tuner below); copy what you want:
+There are no built-in product heads; the extension has only hidden one-shot diagnostics for delivery smoke tests. The [`heads/`](../heads) directory in this repo holds ready-to-use examples (the quality, security, simplifier, and api-design reviewers, plus the foreman and tuner below); copy what you want:
 
 ```bash
 mkdir -p ~/.pi/agent/hydra && cp ~/.pi/agent/git/github.com/pandysp/pi-hydra/heads/*.md ~/.pi/agent/hydra/
@@ -79,7 +79,7 @@ Tracked mutations for `after-change` are successful `write` and `edit` calls. He
 
 ## Decisions: when findings land
 
-An acting head completes only after fallible work has finished, then chooses no feedback, print, steer, or interrupt. Hydra selects and validates the provider-specific completion channel; malformed completion becomes a tool error or noop as described in [Completion channels](providers.md#completion-channels).
+An acting head is instructed to finish fallible work before choosing no feedback, print, steer, or interrupt. For typed completion, Hydra enforces the narrower guarantee that the terminal action is the only tool call in its turn; it cannot prove that every intended check is finished. Hydra selects and validates the provider-specific completion channel, as described in [Completion channels](providers.md#completion-channels).
 
 A judge-only head uses one enumerated findings contract:
 
@@ -89,9 +89,9 @@ A judge-only head uses one enumerated findings contract:
 
 It lists every finding rather than choosing one; an empty array is the quiet result. Each finding chooses its own delivery. Hydra preserves every message exactly once: all `print` findings become one user-only note, while all `steer` and `interrupt` findings become one agent message. That agent message interrupts only if one finding chose `interrupt`; otherwise it steers. A response therefore creates at most two deliveries and never leaks a user-only finding into the agent's context.
 
-- `print`: a note to you. The message renders in the TUI and never enters the agent's context. A watch-only head simply always prints.
+- `print`: a note to you. In interactive mode the message renders in the TUI and never enters the agent's context. A head can choose this route when only the user needs the finding.
 - `steer`: the normal and only agent-directed route. The finding folds into the agent's context as a real user message at its next checkpoint, whether it can wait or not.
-- `interrupt`: the cord. The in-flight run is aborted and the finding opens the next one.
+- `interrupt`: the cord. An active run is aborted and the finding opens the next one; if the snapshot is already stale, Hydra demotes it to steer rather than abort newer work.
 - `none` (acting completions only): nothing to report; nothing is delivered anywhere. In the judge contract silence is the empty findings array: `none` is not a valid finding action, and one invalid action makes hydra discard every finding in that response. `/hydra-stats` labels silent outcomes `noop`.
 
 Delivered to an idle session, steer and interrupt simply open the next run. `after-change` standardizes one narrow write/edit case and does nothing when no mutation occurred. When a head may pull the cord is part of its instruction: a head that should never interrupt is a head whose file says so. The old queue route remains in the extension for compatibility but is not part of the head contract. This holds for project heads and agent-written heads too; the file is the audit trail, and pi's folder trust is the consent boundary.
@@ -100,7 +100,7 @@ Delivered to an idle session, steer and interrupt simply open the next run. `aft
 
 A head's job can be the other heads. Two ship as examples in [`heads/`](../heads):
 
-The **foreman** reads the task and staffs the line: it infers what the session is doing, matches the active set to the phase, and re-crews at transitions. Mark it `autostart: true` and it staffs every fresh session.
+The **foreman** reads the task and staffs the line: it infers what the session is doing, matches the active set to the phase, and re-crews at transitions. Marking it `autostart: true` makes it part of the cold-start set when no explicit flag or saved session set takes precedence.
 
 ```markdown
 ---
@@ -150,7 +150,7 @@ The four review examples are designed to catch different things rather than repe
 
 ### Security
 **Lens:** auth, authorization, secret handling, injection risk, unsafe shelling-out, data exposure, trust boundaries.
-**Why:** Auth logic flaws, leaked secrets, and unsafe shell calls are invisible to every other lens. The agent is thinking about functionality rather than attack surface.
+**Why:** Auth logic flaws, leaked secrets, and unsafe shell calls are easy for general-purpose lenses to miss while the agent is focused on functionality rather than attack surface.
 **Boundary:** Do not comment on style or product scope.
 
 ### Simplifier

--- a/docs/heads.md
+++ b/docs/heads.md
@@ -22,7 +22,7 @@ Frontmatter keys:
 |---|---|---|
 | `name` | yes | the head's identity; what `/hydra-heads` and the `hydra` tool refer to. Files without a name are skipped with a warning. |
 | `description` | yes | one line, shown in completions, the picker, and tool replies. Files without one are skipped with a warning. |
-| `tools` | no | comma-separated tool names the head may execute (`tools: read, grep`). Omitted means all of the agent's tools; `tools: []` means none (the head judges, never acts). |
+| `tools` | no | comma-separated tool names the head may execute (`tools: read, grep`). Omitted means every standard tool hydra can execute; `tools: []` means none (the head judges, never acts). |
 | `autostart` | no | `true` joins the active set at session start. Only consulted when the session has no saved head set and no `--hydra-heads` flag. |
 | `after-change` | no | `noop` or `print`, for heads with `write` or `edit` (or omitted `tools`). After a successful write/edit, hydra requires the matching completion delivery. |
 
@@ -58,7 +58,7 @@ The active set is session state: which heads observe right now.
 - `--hydra-heads quality,security` seeds headless runs (`pi -p`).
 - The agent uses `hydra` with `action: "manage_heads"` to add or remove one head at a time.
 
-Several heads observe at once: each active head gets its own observation in parallel, and each reads the agent's context from the prompt cache, so each additional head costs a cache read instead of a context rebuild.
+Several heads observe at once: each active head gets its own observation in parallel and reuses the agent's cached context instead of rebuilding it. Multiple heads still add material, provider-dependent session cost; see [Economics and measurements](providers.md#economics-and-measurements).
 
 Precedence at session start: an explicit `--hydra-heads` flag wins; otherwise a resumed session restores its saved set; otherwise the heads marked `autostart: true` form the set. Saved state never leaks across sessions; autostart is only the cold-start default.
 
@@ -66,34 +66,28 @@ Precedence at session start: an explicit `--hydra-heads` flag wins; otherwise a 
 
 By default a head may use the agent's standard tools (read, bash, edit, write, grep, find, ls) and the `hydra` tool itself, through pi's own agent loop, before it completes. Those eight are what hydra can execute; a call to anything else the agent carries (another extension's tool, MCP) returns pi's standard error result and the head moves on. A docs head updates notes while the agent works and usually completes with `none`, because its work product is the files it wrote; a research head looks something up and steers the finding in.
 
-`tools:` narrows work actions. A list (`tools: read, grep`) is enforced at execution: the head's prompt states the allowance, and a call outside the list gets pi's standard unknown-tool error, costing the head one recovery turn. `tools: []` makes a judge-only head, which enumerates its findings in one JSON object on both providers (see below). For acting heads, the `hydra` action `complete_observation` remains available on OpenAI because it is the return channel, not a work capability, and Anthropic returns the corresponding decision as compact JSON. On both providers, `manage_heads` is allowed only when `tools` is omitted or explicitly includes `hydra`. The provider payload always advertises the agent's exact tool schemas regardless (byte parity is what keeps observations on the cache), so narrowing changes what a head can execute, never what the request looks like.
+`tools:` narrows work actions. A list (`tools: read, grep`) is enforced at execution: the head's prompt states the allowance, and a call outside the list gets pi's standard unknown-tool error, costing the head one recovery turn. `tools: []` makes a judge-only head, which enumerates its findings in one JSON object (see below). `manage_heads` is allowed only when `tools` is omitted or explicitly includes `hydra`. The provider payload still advertises the driver's exact tool schemas for cache parity, so narrowing changes what a head can execute, never the captured prefix. Hydra chooses the provider's acting-completion channel; [Completion channels](providers.md#completion-channels) is the canonical reference.
 
 Authoring guidance for heads that act:
 
 1. **Write a positive contract.** State the head's purpose, the observable condition that warrants work, the work itself, what done means, and delivery. `PURPOSE / ACT WHEN / WORK / DONE WHEN / DELIVER` is a useful shape, not special syntax. Positive conditions generalize better than accumulating benchmark-shaped exception lists.
-2. **Declare post-mutation delivery where it matters.** After a successful `write` or `edit`, `after-change: noop` requires `delivery: "none"` because the file is the work product; `after-change: print` requires a non-empty printed note. OpenAI enforces a wrong completion as a tool error; Anthropic normalizes the returned decision to the declared delivery. It does not make the head act. Without it, the head chooses delivery.
+2. **Declare post-mutation delivery where it matters.** After a successful `write` or `edit`, `after-change: noop` makes the file the work product; `after-change: print` requires a note. Hydra enforces the declared outcome. It does not make the head act. Without it, the head chooses delivery.
 3. **Avoid state-mutating bash mid-run.** The head works while the agent works. File writes through write/edit serialize against the agent's own writes and are announced in the session; bash output does neither, so keep bash to reads (builds, greps, lookups) unless you accept the race.
 4. **Turns are bounded; spend is not.** A head that has not completed after 25 model turns is wound down with a warning. There is no cost ceiling; the head's instruction is the throttle.
 
-Tracked mutations for `after-change` are successful `write` and `edit` calls. Head-set changes have a separate, stronger contract: a successful observer `manage_heads` call automatically prints one receipt whose factual prefix comes from the runtime and whose message explains why the change fits. Idempotent and failed operations print nothing. Successful self-removal ends the observation immediately; other OpenAI head-set changes are followed by `complete_observation`, while Anthropic returns the equivalent completion object. A head whose `tools` list explicitly includes `hydra` also receives the active-set snapshot at observation start; later tool results are authoritative.
+Tracked mutations for `after-change` are successful `write` and `edit` calls. Head-set changes have a separate, stronger contract: a successful observer `manage_heads` call automatically prints one receipt whose factual prefix comes from the runtime and whose message explains why the change fits. Idempotent and failed operations print nothing. Successful self-removal ends the observation immediately. A head whose `tools` list explicitly includes `hydra` also receives the active-set snapshot at observation start; later tool results are authoritative.
 
 ## Decisions: when findings land
 
-An acting OpenAI head ends with one `hydra` call:
+An acting head completes only after fallible work has finished, then chooses no feedback, print, steer, or interrupt. Hydra selects and validates the provider-specific completion channel; malformed completion becomes a tool error or noop as described in [Completion channels](providers.md#completion-channels).
 
-```json
-{"action":"complete_observation","delivery":"none","message":""}
-```
-
-The call must be alone in its tool-call turn, after fallible work has completed. This makes completion causally last: a parallel write failure cannot be hidden by an already accepted decision. `message` is exactly empty for `none` and non-empty for the other deliveries; invalid combinations are tool errors, not text that hydra guesses how to repair. An acting Anthropic head instead returns `{"action":"noop|print|steer|interrupt","reason":"…","message":"…"}` after its work. Hydra validates that object, but cannot enforce its production with a tool; malformed output becomes `noop`.
-
-A judge-only head uses one enumerated findings contract on both providers (the measured ENUM-SO2 arm in the decision table):
+A judge-only head uses one enumerated findings contract:
 
 ```json
 {"findings":[{"action":"print|steer|interrupt","reason":"≤120 chars","message":"≤240 chars"}]}
 ```
 
-It lists every finding rather than choosing one; an empty array is the quiet result. Each finding chooses its own action (here `action` is the finding's delivery; in the acting call above, `action` names the `hydra` tool operation). Hydra preserves every message exactly once: all `print` findings become one user-only note, while all `steer` and `interrupt` findings become one agent message. That agent message interrupts only if one of its findings chose `interrupt`; otherwise it steers. A response therefore creates at most two deliveries and never leaks a user-only finding into the agent's context. OpenAI carries this contract in a developer envelope beside the raw lens; Anthropic carries both in one prompt.
+It lists every finding rather than choosing one; an empty array is the quiet result. Each finding chooses its own delivery. Hydra preserves every message exactly once: all `print` findings become one user-only note, while all `steer` and `interrupt` findings become one agent message. That agent message interrupts only if one finding chose `interrupt`; otherwise it steers. A response therefore creates at most two deliveries and never leaks a user-only finding into the agent's context.
 
 - `print`: a note to you. The message renders in the TUI and never enters the agent's context. A watch-only head simply always prints.
 - `steer`: the normal and only agent-directed route. The finding folds into the agent's context as a real user message at its next checkpoint, whether it can wait or not.
@@ -143,7 +137,7 @@ DELIVER: Print the edit you made; complete with none when the act condition is
 not met.
 ```
 
-Foreman changes are visible by construction: `manage_heads` accepts a required explanation and auto-prints it only when the set actually changes. Self-removal prints and terminates in that same call. Tuner edits are visible through its `after-change: print` contract: OpenAI rejects a conflicting completion for correction; Anthropic normalizes its returned decision to `print`. A print renders in the TUI and never enters the agent's context. The tuner's file edits also get the standard write notice the agent sees; the notice records the change and carries no finding. The two combine well: a foreman can activate the tuner when a session warrants it.
+Foreman changes are visible by construction: `manage_heads` accepts a required explanation and auto-prints it only when the set actually changes. Self-removal prints and terminates in that same call. Tuner edits are visible through its `after-change: print` contract. A print renders in the TUI and never enters the agent's context. The tuner's file edits also get the standard write notice the agent sees; the notice records the change and carries no finding. The two combine well: a foreman can activate the tuner when a session warrants it.
 
 ## Example heads (minimal overlap)
 
@@ -216,6 +210,6 @@ Heads whose subject is the other heads (the foreman and tuner) are covered in [H
 2. **Against the grain:** The best heads watch what the agent naturally ignores.
 3. **Actionable:** Feedback must be specific enough to act on (not "consider security").
 4. **Bounded:** Clear "do NOT comment on..." prevents overlap.
-5. **Short:** The instruction is the only uncached part of a mid-run observation (run-end observations additionally pay the final message's cache write); keep it tight.
+5. **Short:** The head instruction is fresh input, so keep it tight. Provider-specific run-end accounting lives in [Provider lifecycle](providers.md#provider-lifecycle).
 
 Overlap notes: Simplifier and Performance both catch redundant operations, so run one or the other; Devil's Advocate and Observability do not overlap with the four review examples.

--- a/docs/inbound-links.json
+++ b/docs/inbound-links.json
@@ -1,7 +1,7 @@
 {
   "description": "Pre-refactor inbound links to outward pi-hydra documentation. Targets are checkout-relative; provenance records every source occurrence found by the reproducible scan.",
   "generatedFrom": {
-    "requestedRef": "main",
+    "requestedRef": "4b140d77023446406bd6e41cb5559866bedf595f",
     "repoCommit": "4b140d77023446406bd6e41cb5559866bedf595f",
     "workspaceScanned": true
   },

--- a/docs/inbound-links.json
+++ b/docs/inbound-links.json
@@ -1,0 +1,108 @@
+{
+  "description": "Pre-refactor inbound links to outward pi-hydra documentation. Targets are checkout-relative; provenance records every source occurrence found by the reproducible scan.",
+  "generatedFrom": {
+    "requestedRef": "main",
+    "repoCommit": "4b140d77023446406bd6e41cb5559866bedf595f",
+    "workspaceScanned": true
+  },
+  "targets": [
+    {
+      "path": "CONTRIBUTING.md",
+      "fragment": "",
+      "provenance": [
+        "repo@4b140d77023446406bd6e41cb5559866bedf595f:README.md:52",
+        "repo@4b140d77023446406bd6e41cb5559866bedf595f:README.md:132",
+        "repo@4b140d77023446406bd6e41cb5559866bedf595f:docs/architecture.md:175"
+      ]
+    },
+    {
+      "path": "docs/architecture.md",
+      "fragment": "",
+      "provenance": [
+        "repo@4b140d77023446406bd6e41cb5559866bedf595f:CONTRIBUTING.md:30",
+        "repo@4b140d77023446406bd6e41cb5559866bedf595f:CONTRIBUTING.md:36",
+        "repo@4b140d77023446406bd6e41cb5559866bedf595f:README.md:118"
+      ]
+    },
+    {
+      "path": "docs/architecture.md",
+      "fragment": "cache-hit-ratio",
+      "provenance": [
+        "repo@4b140d77023446406bd6e41cb5559866bedf595f:README.md:21"
+      ]
+    },
+    {
+      "path": "docs/architecture.md",
+      "fragment": "commit-point-observation",
+      "provenance": [
+        "repo@4b140d77023446406bd6e41cb5559866bedf595f:docs/architecture.md:133"
+      ]
+    },
+    {
+      "path": "docs/architecture.md",
+      "fragment": "observation-timing",
+      "provenance": [
+        "repo@4b140d77023446406bd6e41cb5559866bedf595f:experiments/README.md:307"
+      ]
+    },
+    {
+      "path": "docs/architecture.md",
+      "fragment": "openai-codex-support",
+      "provenance": [
+        "repo@4b140d77023446406bd6e41cb5559866bedf595f:README.md:44",
+        "repo@4b140d77023446406bd6e41cb5559866bedf595f:README.md:122",
+        "repo@4b140d77023446406bd6e41cb5559866bedf595f:docs/architecture.md:11",
+        "repo@4b140d77023446406bd6e41cb5559866bedf595f:docs/architecture.md:161"
+      ]
+    },
+    {
+      "path": "docs/architecture.md",
+      "fragment": "verifying-the-tripwire",
+      "provenance": [
+        "repo@4b140d77023446406bd6e41cb5559866bedf595f:docs/architecture.md:101"
+      ]
+    },
+    {
+      "path": "docs/heads.md",
+      "fragment": "",
+      "provenance": [
+        "repo@4b140d77023446406bd6e41cb5559866bedf595f:CONTRIBUTING.md:28",
+        "repo@4b140d77023446406bd6e41cb5559866bedf595f:README.md:85",
+        "repo@4b140d77023446406bd6e41cb5559866bedf595f:docs/architecture.md:39",
+        "repo@4b140d77023446406bd6e41cb5559866bedf595f:docs/architecture.md:155"
+      ]
+    },
+    {
+      "path": "docs/heads.md",
+      "fragment": "heads-that-manage-heads",
+      "provenance": [
+        "repo@4b140d77023446406bd6e41cb5559866bedf595f:docs/heads.md:211"
+      ]
+    },
+    {
+      "path": "README.md",
+      "fragment": "",
+      "provenance": [
+        "repo@4b140d77023446406bd6e41cb5559866bedf595f:archive/README.md:3",
+        "repo@4b140d77023446406bd6e41cb5559866bedf595f:archive/README.md:11",
+        "repo@4b140d77023446406bd6e41cb5559866bedf595f:docs/architecture.md:3"
+      ]
+    },
+    {
+      "path": "README.md",
+      "fragment": "what-it-costs",
+      "provenance": [
+        "repo@4b140d77023446406bd6e41cb5559866bedf595f:README.md:9",
+        "repo@4b140d77023446406bd6e41cb5559866bedf595f:README.md:15",
+        "repo@4b140d77023446406bd6e41cb5559866bedf595f:README.md:126"
+      ]
+    },
+    {
+      "path": "README.md",
+      "fragment": "where-this-is-going",
+      "provenance": [
+        "repo@4b140d77023446406bd6e41cb5559866bedf595f:README.md:125"
+      ]
+    }
+  ]
+}

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,0 +1,195 @@
+# Providers and measurements
+
+This is the canonical reference for pi-hydra's provider behavior, measured model coverage, cache economics, dated results, volatility caveats, and evidence links. The [README](../README.md) explains the product; [Architecture](architecture.md) explains the provider-neutral system.
+
+All numbers here describe measured regimes, not universal surcharges or timeless backend constants. Re-run the probes after Pi or provider changes.
+
+## Supported provider boundary
+
+Observation is enabled only for provider/API pairs whose replay safety and cache behavior have been measured:
+
+- Anthropic with `anthropic-messages`;
+- OpenAI Codex with `openai-codex-responses`, validated on GPT-5.6.
+
+Older Codex models pass the same runtime gate but their cache economics are unvalidated. The OpenAI API-key path shares serializer code but remains disabled until measured. Other pairs warn once and skip observation rather than risk full-price replay or driver breakage.
+
+Heads always use the driver's model, tool schemas, and thinking configuration. Prompt caches are model-specific; choosing another model would forfeit the shared prefix.
+
+## Provider lifecycle
+
+### Mid-run
+
+hydra captures the driver's request in `before_provider_request` and schedules after the response begins at `message_start`.
+
+On Anthropic, probes verified that the cache entry becomes readable at response start with no distinguishable propagation delay: commit+0 observations on Haiku and Fable, with and without thinking, read the committed prefix. A mid-run observation therefore keeps the captured prefix byte-identical and appends only its fresh handoff.
+
+Codex uses the same lifecycle trigger, but commit/read timing is looser. An observation reads whatever has committed and may pay the uncached remainder. Backend observations in July 2026 ranged from near-instant in full-stack traffic to a controlled read becoming available within 65 seconds; timing changes economics, not delivery safety.
+
+The first response of each run is skipped because the previous run-end observation reviewed the preceding state.
+
+### Run end
+
+A request never caches the assistant response it produces. At `agent_end`, hydra therefore carries the final assistant message M into the observation through Pi's own provider serialization.
+
+On Anthropic, hydra moves the driver's deepest message-level cache marker, including its TTL, onto M's last markable block. M changes from fresh input at 1.0× to a cache write at 1.25×, a 0.25× premium; the driver's next turn then reads it at 0.1× instead of writing it at 1.25×, a 1.15× saving. This is the roughly 5:1 pre-warm bet. Human latency is normally longer than observation TTFT, so M is warm before the next prompt.
+
+On Codex, the merge is marker-free and implicit caching controls the frontier. The run-end observation currently pays the newest turn plus its observer tail; do not apply Anthropic's explicit pre-warm accounting to it.
+
+M is selected by identity: hydra records the response message's own timestamp at `message_start` and requires an exact match at run end. Wall-clock comparisons lost M nondeterministically in same-millisecond measurements. Errored or aborted final requests correctly attach nothing.
+
+## Provider payload mechanics
+
+### Anthropic
+
+The captured content prefix is cloned and the observation tail is appended. For a plain mid-run handoff, no cache marker moves. At run end, the deepest message-level marker moves onto M. During an acting loop, it advances to the tail's last markable block, so each loop turn is written once and read on later iterations. Loop markers are plain ephemeral markers rather than the driver's longer TTL.
+
+Only text, `tool_use`, and `tool_result` blocks can carry the marker; thinking blocks cannot. The merge relocates an existing breakpoint rather than adding a fifth one beyond Anthropic's four-breakpoint request budget.
+
+Anthropic receives one combined user handoff. In a July 2026 A/B, a separate system envelope tied review accuracy at 64.4%, reduced parse validity from 100% to 96.7%, helped Opus but regressed Sonnet, and added 744 ms mean latency. A model-specific capability gate was rejected, so all Anthropic models keep the combined form.
+
+### OpenAI Codex
+
+The merge appends Pi's serialization of `[M?, user lens, loop turns…]` to the captured `input`, then inserts Hydra's stable developer envelope immediately after the user lens. It touches no other captured field and removes explicit prompt breakpoints from the tail because this backend uses implicit caching.
+
+A combined-user treatment was also entitlement-unsafe: after included quota was exhausted, all 24 final-candidate combined-user calls failed with `The usage limit has been reached` while adjacent user-lens-plus-developer-envelope controls succeeded. The split form is both the measured higher-quality protocol and the safe route for that backend.
+
+The first developer-envelope treatment cut extra observer turns from 67 to 3 while preserving total-loop cache hit (83.07% versus 83.30%). Review-action accuracy rose from 72.2% to 84.4%; after the generic envelope was tightened so the lens alone controls scope and intervention, a fresh treatment reached 98.9% (88/89 API-successful calls) versus 72.2% for saved controls. Two blinded judges preferred treatment 62 times, control 15 times, with 103 ties.
+
+## Completion channels
+
+Judge-only heads use one enumerated findings object on both providers. Malformed output fails open to noop without a repair call. Hydra preserves all valid messages in at most two batches: prints to the user, and steers/interrupts to the agent.
+
+Acting OpenAI heads call the typed `hydra` completion action exactly once, alone in its assistant turn. Acting Anthropic heads return compact JSON after their work; native typed completion measured materially slower and more expensive there. Work and head management remain real tools on both providers.
+
+Across 78 randomized OpenAI acting pairs on Luna, Terra, and Sol, the final generic design scored 77/78 (98.7%) versus 63/78 (80.8%), used 201 versus 227 calls, cost $0.7499 versus $0.8330, and reduced mean latency from 7.99 s to 7.10 s. By family: docs 29/30 versus 21/30, tuner 18/18 versus 12/18, foreman 30/30 versus 30/30. A separate frozen foreman screen makes the combined result 45/45 versus 44/45.
+
+The same contracts on Anthropic scored 38/42 versus 31/42 across Sonnet, Opus, and Fable, with seven treatment-only wins, no control-only wins, and four shared misses. Treatment used 112 versus 120 calls, cost $0.7285 versus $0.7782, and reduced mean/p95 latency from 7.37/12.01 s to 7.05/11.67 s. Parse validity was 41/42 versus 42/42.
+
+A final OpenAI completion-transport A/B covered 144 review pairs and 96 acting pairs. Typed completion was valid in 144/144 reviews versus 142/144 for JSON and removed 23 retry turns; semantic review accuracy was 42/144 versus 40/144, mean latency 6.68 versus 6.71 s, and cost was 16.7% higher. Acting accuracy was 95/96 versus 96/96. Terminal self-removal stayed 24/24 while mean latency fell from 5.61 s to 3.09 s. The [experiment log](https://github.com/pandysp/pi-hydra/blob/openai-cache-clean/experiments/README.md#enforceable-completion-ab-july-2026) carries the full KPI table.
+
+## OpenAI Codex
+
+### Session sharing
+
+Controlled probes found Codex cache routing strongly session-sensitive. Sharing the driver's provider session lets observations reliably read entries the driver wrote and lets later calls find observation writes. It is structurally safe only when the driver sends full input each turn: Pi transport `websocket` or `sse`.
+
+Under continuation transport such as `auto`, the driver relies on `previous_response_id` bookkeeping in a different Pi AI module instance. An observation sharing that session can evict the referenced response and break the driver's next request (`Previous response … not found`). This reproduced 2/2 under `auto` and 0 times under `websocket`.
+
+hydra pins the initial sharing decision at the first `agent_start`, re-reads transport before every observation, and moves only one way: once sharing becomes unsafe it uses one observer-owned UUIDv7 for the rest of the session. It never upgrades back, because stale continuation state could be resurrected.
+
+### Tripwire
+
+If a driver request ends with the known continuation-error signature, hydra permanently retreats to its own session and reports why. In-flight acting heads wind down at their next turn boundary. A live-fire July 2026 verification forced unsafe sharing, reproduced one driver failure, observed the permanent retreat, and saw Pi recover on retry. One race remains: a settings flip while a shared observation is in flight may cause one failure before the tripwire acts.
+
+### Backend volatility
+
+Treat these July 2026 observations as dated snapshots:
+
+- Controlled cache entries appeared session-scoped, though full-stack traffic occasionally showed cross-session reads of identical content.
+- Read granularity moved from reported 128-token blocks on July 13–14 to 512-token steps in a July 24 Pi 0.82 probe.
+- Entry lifetime moved from roughly 2–9 minutes on July 13 to under roughly 85 seconds idle on July 14.
+- GPT-5.6 rejected missing/v4 session IDs and SSE on July 13, then accepted them July 14.
+- `cache_write_tokens` was never reported on the subscription backend.
+
+hydra's safety does not depend on those values. UUIDv7, websocket observation transport, monotone fallback, and the tripwire remain costless invariants that were required at least once.
+
+## Economics and measurements
+
+### Anthropic cache hit
+
+The handoff is the main fresh input, so hit ratio rises with driver context:
+
+| Driver context | Observation handoff | Theoretical hit |
+|---:|---:|---:|
+| 4K | 220 | 94.8% |
+| 10K | 220 | 97.8% |
+| 30K | 220 | 99.3% |
+| 100K | 220 | 99.8% |
+
+An earlier real three-prompt session with four observations measured 97.92% aggregate and $0.0202 total observation cost: 87.79% at a 3.5K cold start, then 98.11%, 99.07%, and 99.12% as context grew. Current commit-point live E2E on Fable/xhigh measured 7/7 piggyback observations as pure reads with write=0, while each run-end fork wrote exactly M.
+
+Across live Anthropic sessions, one always-on head cost 32.5%–61.4% of driver cost. This is a measured range, not a fixed surcharge.
+
+### Codex cache hit and cost
+
+Healthy shared-mode Codex observations measured roughly 84%–87% cache hit. A July 2026 live E2E on GPT-5.6 Luna ranged from 87.4% on the first piggyback to 84.1% on the final run-end observation; individual calls cost about $0.0015–$0.0021 and driver cache hit stayed near 87% with no errors.
+
+In the registered production-shaped wave of August 3, 2026, six driver runs compared the shipped enumerate-all-findings contract (ENUM) with a single-finding baseline (MAIN). Across cache-comparable observations, MAIN cost $0.0253 per observation and 52.1% of driver cost (103 observations); ENUM cost $0.0356 and 77.0% (108 observations). Including all charged cache misses and calls after failed driver turns raised those ratios to 66.2% and 93.3%. These establish cost only; the quality benchmark was still in progress. See [capstone producer results](https://github.com/pandysp/pi-hydra/blob/openai-cache-clean/experiments/OPENAI-CAPSTONE-PRODUCER-RESULTS.md).
+
+### Interpreting the numbers
+
+An observation can be cheap while an always-on session is materially more expensive: heads observe repeatedly, and multiple heads fan out per trigger. Output volume, task shape, model, reasoning level, provider retention, and cache misses all matter. On subscription Codex, observation spend uses the same account quota as the driver.
+
+`/hydra-stats` is the authority for the current session. The repository [decision table](https://github.com/pandysp/pi-hydra/blob/openai-cache-clean/experiments/DECISION-TABLE.md) and [experiment index](https://github.com/pandysp/pi-hydra/blob/openai-cache-clean/experiments/INDEX.md) are the durable evidence for published waves.
+
+## Provider limits
+
+- **Anthropic cold start:** the first observation may fall below the 97% target because the handoff is large relative to a tiny initial context.
+- **Codex commit window:** an observation racing commit may pay its snapshot as fresh input once; this degrades economics rather than correctness.
+- **Codex fallback:** observer-scoped sessions pay the driver context once and may repay after idle expiry.
+- **Headless shutdown:** Pi may exit before a slow run-end observation finishes. `HYDRA_SHUTDOWN_GRACE_MS` defaults to 5 seconds; raise it for headless verification (`0` means do not wait).
+- **Multi-head run end:** heads run in parallel for low latency. On Anthropic each run-end fork may pay M's write rather than coordinating a follower free-ride; measured contention remained a single-digit share of observation spend.
+- **Long tools:** acting heads wind down at turn boundaries, but a long bash execution may outlive shutdown grace.
+- **Partial output:** heads judge committed snapshots, never an unfinished generation.
+- **Unverified paths:** OpenAI API-key transport, older Codex model economics, and provider behavior outside the measured pairs remain out of scope.
+
+## Verification procedures
+
+### Cache parity
+
+In an active session:
+
+```bash
+/hydra-debug
+# perform work
+/hydra-debug
+ls /tmp/hydra-debug-*/
+```
+
+For an Anthropic mid-run pair, dropping the appended handoff must reproduce the driver request:
+
+```bash
+jq -S '.' <driver.json> > /tmp/drv.json
+jq -S 'del(.messages[-1])' <observation.json> > /tmp/obs.json
+diff /tmp/drv.json /tmp/obs.json
+```
+
+For Anthropic run end, drop M and the handoff and ignore deliberate marker relocation:
+
+```bash
+jq -S 'walk(if type == "object" then del(.cache_control) else . end)' <driver.json> > /tmp/drv.json
+jq -S 'del(.messages[-2:]) | walk(if type == "object" then del(.cache_control) else . end)' <observation.json> > /tmp/obs.json
+diff /tmp/drv.json /tmp/obs.json
+```
+
+For Codex, truncate observation input to the driver length:
+
+```bash
+N=$(jq '.input | length' <driver.json>)
+jq -S '.' <driver.json> > /tmp/drv.json
+jq -S --argjson n "$N" '.input |= .[:$n]' <observation.json> > /tmp/obs.json
+diff /tmp/drv.json /tmp/obs.json
+```
+
+A stricter cross-process Anthropic check runs two headless prompts in one session directory. The second driver's first `cacheRead` should equal the first run's committed prefix plus M, and `cacheWrite` should be approximately the new user prompt:
+
+```bash
+HYDRA_SHUTDOWN_GRACE_MS=120000 pi -p --session-dir /tmp/v "Explain TCP slow start in 200 words, plain text, no tools."
+HYDRA_SHUTDOWN_GRACE_MS=120000 pi -p -c --session-dir /tmp/v "Thanks. One sentence: what is the congestion window?"
+jq -r 'select(.type=="message" and .message.role=="assistant") | .message.usage | [.cacheRead, .cacheWrite, .output] | @csv' /tmp/v/*.jsonl
+```
+
+### Verifying the Codex tripwire
+
+This intentionally breaks one request. Use only a throwaway session:
+
+```bash
+cd /tmp/scratch-project
+HYDRA_UNSAFE_FORCE_SHARE=1 pi --model openai-codex/gpt-5.6-luna
+```
+
+1. Turn 1 lets observations share the driver's session unsafely.
+2. Turn 2 should fail once with `Previous response … not found`; the warning announces permanent retreat and Pi's retry recovers.
+3. Turn 3 onward should observe in Hydra's own scope with no repeated driver failure.
+
+The unsafe flag skips only the transport gate; monotone state and the tripwire remain active.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -25,13 +25,13 @@ On Anthropic, probes verified that the cache entry becomes readable at response 
 
 Codex uses the same lifecycle trigger, but commit/read timing is looser. An observation reads whatever has committed and may pay the uncached remainder. Backend observations in July 2026 ranged from near-instant in full-stack traffic to a controlled read becoming available within 65 seconds; timing changes economics, not delivery safety.
 
-The first response of each run is skipped because the previous run-end observation reviewed the preceding state.
+The first response of each run is skipped unconditionally. On later runs, the previous run-end observation covered the preceding state; in a fresh session, the first review arrives at an eligible later snapshot or at run end.
 
 ### Run end
 
-A request never caches the assistant response it produces. At `agent_end`, hydra therefore carries the final assistant message M into the observation through Pi's own provider serialization.
+The assistant response a request produces is not part of that request's prompt-cache input. At `agent_end`, hydra therefore carries the final assistant message M into the observation through Pi's own provider serialization.
 
-On Anthropic, hydra moves the driver's deepest message-level cache marker, including its TTL, onto M's last markable block. M changes from fresh input at 1.0× to a cache write at 1.25×, a 0.25× premium; the driver's next turn then reads it at 0.1× instead of writing it at 1.25×, a 1.15× saving. This is the roughly 5:1 pre-warm bet. Human latency is normally longer than observation TTFT, so M is warm before the next prompt.
+On Anthropic, hydra moves the driver's deepest message-level cache marker, including its TTL, onto M's last markable block. With the five-minute marker used in the retained measurements, M changes from fresh input at 1.0× to a cache write at 1.25×, a 0.25× premium; the driver's next turn then reads it at 0.1× instead of writing it at 1.25×, a 1.15× saving—the roughly 5:1 pre-warm bet. A one-hour marker has a different write premium, so current economics depend on the driver's retention setting. Human latency is normally longer than observation TTFT, so M is usually warm before the next prompt.
 
 On Codex, the merge is marker-free and implicit caching controls the frontier. The run-end observation currently pays the newest turn plus its observer tail; do not apply Anthropic's explicit pre-warm accounting to it.
 
@@ -59,7 +59,7 @@ The first developer-envelope treatment cut extra observer turns from 67 to 3 whi
 
 Judge-only heads use one enumerated findings object on both providers. Malformed output fails open to noop without a repair call. Hydra preserves all valid messages in at most two batches: prints to the user, and steers/interrupts to the agent.
 
-Acting OpenAI heads call the typed `hydra` completion action exactly once, alone in its assistant turn. Acting Anthropic heads return compact JSON after their work; native typed completion measured materially slower and more expensive there. Work and head management remain real tools on both providers.
+A non-self-removing acting OpenAI head is expected to call the typed `hydra` completion action once; Hydra enforces that a terminal action is alone in its tool-call turn. Successful self-removal is terminal without a separate completion call. Acting Anthropic heads are instructed to return compact JSON after their work; native typed completion measured materially slower and more expensive there. Work and head management remain real tools on both providers.
 
 Across 78 randomized OpenAI acting pairs on Luna, Terra, and Sol, the final generic design scored 77/78 (98.7%) versus 63/78 (80.8%), used 201 versus 227 calls, cost $0.7499 versus $0.8330, and reduced mean latency from 7.99 s to 7.10 s. By family: docs 29/30 versus 21/30, tuner 18/18 versus 12/18, foreman 30/30 versus 30/30. A separate frozen foreman screen makes the combined result 45/45 versus 44/45.
 
@@ -71,7 +71,7 @@ A final OpenAI completion-transport A/B covered 144 review pairs and 96 acting p
 
 ### Session sharing
 
-Controlled probes found Codex cache routing strongly session-sensitive. Sharing the driver's provider session lets observations reliably read entries the driver wrote and lets later calls find observation writes. It is structurally safe only when the driver sends full input each turn: Pi transport `websocket` or `sse`.
+Controlled probes found Codex cache routing strongly session-sensitive. Sharing the driver's provider session reliably co-locates observations with entries the driver wrote; what later calls reuse still depends on the backend's implicit cache behavior. Sharing is structurally safe only when the driver sends full input each turn: Pi transport `websocket` or `sse`.
 
 Under continuation transport such as `auto`, the driver relies on `previous_response_id` bookkeeping in a different Pi AI module instance. An observation sharing that session can evict the referenced response and break the driver's next request (`Previous response … not found`). This reproduced 2/2 under `auto` and 0 times under `websocket`.
 
@@ -79,7 +79,7 @@ hydra pins the initial sharing decision at the first `agent_start`, re-reads tra
 
 ### Tripwire
 
-If a driver request ends with the known continuation-error signature, hydra permanently retreats to its own session and reports why. In-flight acting heads wind down at their next turn boundary. A live-fire July 2026 verification forced unsafe sharing, reproduced one driver failure, observed the permanent retreat, and saw Pi recover on retry. One race remains: a settings flip while a shared observation is in flight may cause one failure before the tripwire acts.
+If a driver request ends with the known continuation-error signature, hydra permanently retreats to its own session and, when heads are active, reports why. In-flight acting heads wind down at their next turn boundary. A live-fire July 2026 verification forced unsafe sharing, reproduced one driver failure, observed the permanent retreat, and saw Pi recover on retry. One race remains: a settings flip while a shared observation is in flight may cause one failure before the tripwire acts.
 
 ### Backend volatility
 
@@ -97,18 +97,11 @@ hydra's safety does not depend on those values. UUIDv7, websocket observation tr
 
 ### Anthropic cache hit
 
-The handoff is the main fresh input, so hit ratio rises with driver context:
+The handoff is the main fresh input, so hit ratio generally rises with driver context. The former 220-token table was only an illustration for a fixed handoff size; current handoff size varies with mode and delivery context, so measured sessions are the useful reference.
 
-| Driver context | Observation handoff | Theoretical hit |
-|---:|---:|---:|
-| 4K | 220 | 94.8% |
-| 10K | 220 | 97.8% |
-| 30K | 220 | 99.3% |
-| 100K | 220 | 99.8% |
+An earlier three-prompt session with four observations measured 97.92% aggregate and $0.0202 total observation cost: 87.79% at a 3.5K cold start, then 98.11%, 99.07%, and 99.12% as context grew. A retained commit-point live E2E on Fable/xhigh measured 7/7 piggyback observations as pure reads with write=0, while each run-end fork wrote exactly M.
 
-An earlier real three-prompt session with four observations measured 97.92% aggregate and $0.0202 total observation cost: 87.79% at a 3.5K cold start, then 98.11%, 99.07%, and 99.12% as context grew. Current commit-point live E2E on Fable/xhigh measured 7/7 piggyback observations as pure reads with write=0, while each run-end fork wrote exactly M.
-
-Across live Anthropic sessions, one always-on head cost 32.5%–61.4% of driver cost. This is a measured range, not a fixed surcharge.
+Across retained live Anthropic sessions using five-minute cache retention, one always-on head cost 32.5%–61.4% of driver cost. This is a measured historical range, not a fixed surcharge; retention changes the write economics.
 
 ### Codex cache hit and cost
 
@@ -130,7 +123,7 @@ An observation can be cheap while an always-on session is materially more expens
 - **Headless shutdown:** Pi may exit before a slow run-end observation finishes. `HYDRA_SHUTDOWN_GRACE_MS` defaults to 5 seconds; raise it for headless verification (`0` means do not wait).
 - **Multi-head run end:** heads run in parallel for low latency. On Anthropic each run-end fork may pay M's write rather than coordinating a follower free-ride; measured contention remained a single-digit share of observation spend.
 - **Long tools:** acting heads wind down at turn boundaries, but a long bash execution may outlive shutdown grace.
-- **Partial output:** heads judge committed snapshots, never an unfinished generation.
+- **Partial output:** heads judge complete captured requests, never an unfinished generation.
 - **Unverified paths:** OpenAI API-key transport, older Codex model economics, and provider behavior outside the measured pairs remain out of scope.
 
 ## Verification procedures

--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
 		]
 	},
 	"scripts": {
-		"check": "tsc && node module-state.check.mjs",
+		"check": "tsc && node module-state.check.mjs && npm run check:links && npm run check:docs",
+		"check:links": "node scripts/check-links.mjs",
+		"check:docs": "node scripts/check-doc-claims.mjs",
+		"update:doc-claims": "node scripts/check-doc-claims.mjs --update",
 		"test": "vitest run"
 	},
 	"devDependencies": {

--- a/scripts/build-inbound-inventory.mjs
+++ b/scripts/build-inbound-inventory.mjs
@@ -4,7 +4,8 @@ import { dirname, join, posix, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const ref = process.argv.find((arg) => arg.startsWith("--ref="))?.slice(6) ?? "main";
+const PRE_REFACTOR_COMMIT = "4b140d77023446406bd6e41cb5559866bedf595f";
+const ref = process.argv.find((arg) => arg.startsWith("--ref="))?.slice(6) ?? PRE_REFACTOR_COMMIT;
 const resolvedRef = execFileSync("git", ["rev-parse", `${ref}^{commit}`], { cwd: root, encoding: "utf8" }).trim();
 const workspace = process.argv.find((arg) => arg.startsWith("--workspace="))?.slice(12) ?? "/Users/spannagel/main-workspace";
 const outward = new Set(["README.md", "CONTRIBUTING.md", "docs/architecture.md", "docs/heads.md"]);

--- a/scripts/build-inbound-inventory.mjs
+++ b/scripts/build-inbound-inventory.mjs
@@ -1,0 +1,133 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, posix, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const ref = process.argv.find((arg) => arg.startsWith("--ref="))?.slice(6) ?? "main";
+const resolvedRef = execFileSync("git", ["rev-parse", `${ref}^{commit}`], { cwd: root, encoding: "utf8" }).trim();
+const workspace = process.argv.find((arg) => arg.startsWith("--workspace="))?.slice(12) ?? "/Users/spannagel/main-workspace";
+const outward = new Set(["README.md", "CONTRIBUTING.md", "docs/architecture.md", "docs/heads.md"]);
+const records = new Map();
+
+function add(path, fragment, provenance) {
+	if (!outward.has(path)) return;
+	const key = `${path}#${fragment}`;
+	const record = records.get(key) ?? { path, fragment, provenance: [] };
+	if (!record.provenance.includes(provenance)) record.provenance.push(provenance);
+	records.set(key, record);
+}
+
+function decode(value) {
+	try { return decodeURIComponent(value); } catch { return value; }
+}
+
+function maskCode(markdown) {
+	let fenced = false;
+	return markdown.split(/(\r?\n)/).map((part) => {
+		if (/^\r?\n$/.test(part)) return part;
+		if (/^\s*(```|~~~)/.test(part)) {
+			fenced = !fenced;
+			return " ".repeat(part.length);
+		}
+		if (fenced) return " ".repeat(part.length);
+		return part.replace(/(`+)(.*?)\1/g, (match) => " ".repeat(match.length));
+	}).join("");
+}
+
+function inspectMarkdown(original, sourcePath, sourceLabel, repoSource) {
+	const markdown = maskCode(original);
+	const candidates = [];
+	const collect = (regex, group = 1) => {
+		for (const match of markdown.matchAll(regex)) candidates.push({ raw: match[group], index: match.index });
+	};
+	// Inline links/images, reference definitions, autolinks, HTML attributes,
+	// bare repository GitHub URLs, file URLs, and absolute checkout paths.
+	collect(/!?\[[^\]]*\]\(([^)]+)\)/g);
+	collect(/^\s*\[[^\]]+\]:\s*(?:<([^>]+)>|(\S+))/gm, 1);
+	for (const match of markdown.matchAll(/^\s*\[[^\]]+\]:\s*(?:<([^>]+)>|(\S+))/gm)) {
+		if (match[2]) candidates.push({ raw: match[2], index: match.index });
+	}
+	collect(/<(https?:\/\/github\.com\/pandysp\/pi-hydra\/[^>\s]+|file:\/\/[^>\s]+)>/g);
+	collect(/(?:href|src)=["']([^"']+)["']/gi);
+	collect(/(?<![<("'])https?:\/\/github\.com\/pandysp\/pi-hydra\/(?:blob|tree)\/[^\s)>"']+/g, 0);
+	collect(/(?<![<("'])file:\/\/\/Users\/spannagel\/dev\/personal\/pi-hydra\/[^\s)>"']+/g, 0);
+	collect(/(?<![\w])\/Users\/spannagel\/dev\/personal\/pi-hydra\/(?:README\.md|CONTRIBUTING\.md|docs\/(?:architecture|heads)\.md)(?:#[^\s)>"']+)?/g, 0);
+	collect(/(?<![\w])~\/dev\/personal\/pi-hydra\/(?:README\.md|CONTRIBUTING\.md|docs\/(?:architecture|heads)\.md)(?:#[^\s)>"']+)?/g, 0);
+
+	for (const { raw: untrimmed, index } of candidates) {
+		if (!untrimmed) continue;
+		const raw = untrimmed.trim().replace(/\s+["'][^"']*["']\s*$/, "").replace(/^file:\/\//, "").replace(/^~\//, "/Users/spannagel/");
+		const line = original.slice(0, index).split("\n").length;
+		const provenance = `${sourceLabel}:${sourcePath}:${line}`;
+		const github = /^https?:\/\/github\.com\/pandysp\/pi-hydra\/(?:blob|tree)\/[^/]+\/(.+?)(?:#([^\s]+))?$/.exec(raw);
+		if (github) {
+			add(decode(github[1]), decode(github[2] ?? ""), provenance);
+			continue;
+		}
+		if (/^[a-z]+:/i.test(raw)) continue;
+		const [pathPart, fragment = ""] = raw.split("#", 2);
+		if (repoSource && !pathPart.startsWith("/")) {
+			const target = pathPart ? posix.normalize(posix.join(posix.dirname(sourcePath), decode(pathPart))) : sourcePath;
+			add(target, decode(fragment), provenance);
+		} else {
+			const absolute = pathPart.startsWith("/") ? pathPart : resolve(dirname(join(workspace, sourcePath)), decode(pathPart));
+			const prefix = `${root}/`;
+			if (absolute.startsWith(prefix)) add(relative(root, absolute).replaceAll("\\", "/"), decode(fragment), provenance);
+		}
+	}
+}
+
+function selfTest() {
+	const repoFixture = [
+		"[inline](README.md#fixture-inline)",
+		"[reference]: <README.md#fixture-reference>",
+	].join("\n");
+	const workspaceFixture = [
+		"<https://github.com/pandysp/pi-hydra/blob/main/README.md#fixture-autolink>",
+		"<a href=\"https://github.com/pandysp/pi-hydra/blob/main/README.md#fixture-html\">x</a>",
+		"https://github.com/pandysp/pi-hydra/blob/main/README.md#fixture-bare",
+		"file:///Users/spannagel/dev/personal/pi-hydra/README.md#fixture-file",
+		"/Users/spannagel/dev/personal/pi-hydra/README.md#fixture-absolute",
+		"~/dev/personal/pi-hydra/README.md#fixture-tilde",
+	].join("\n");
+	inspectMarkdown(repoFixture, "fixture.md", "fixture", true);
+	inspectMarkdown(workspaceFixture, "fixture.md", "fixture", false);
+	for (const fragment of ["inline", "reference", "autolink", "html", "bare", "file", "absolute", "tilde"].map((name) => `fixture-${name}`)) {
+		const key = `README.md#${fragment}`;
+		if (!records.has(key)) throw new Error(`inbound inventory self-test missed ${fragment} link form`);
+		records.delete(key);
+	}
+}
+
+selfTest();
+const tracked = execFileSync("git", ["ls-tree", "-r", "--name-only", resolvedRef], { cwd: root, encoding: "utf8" })
+	.split("\n").filter((path) => path.endsWith(".md"));
+for (const path of tracked) {
+	const markdown = execFileSync("git", ["show", `${resolvedRef}:${path}`], { cwd: root, encoding: "utf8", maxBuffer: 20 * 1024 * 1024 });
+	inspectMarkdown(markdown, path, `repo@${resolvedRef}`, true);
+}
+
+function workspaceMarkdown(dir) {
+	const found = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		if ([".git", ".qmd", "node_modules"].includes(entry.name)) continue;
+		const path = join(dir, entry.name);
+		if (entry.isDirectory()) found.push(...workspaceMarkdown(path));
+		else if (entry.isFile() && entry.name.endsWith(".md")) found.push(path);
+	}
+	return found;
+}
+if (existsSync(workspace)) {
+	for (const path of workspaceMarkdown(workspace)) {
+		inspectMarkdown(readFileSync(path, "utf8"), relative(workspace, path), "main-workspace", false);
+	}
+}
+
+const inventory = {
+	description: "Pre-refactor inbound links to outward pi-hydra documentation. Targets are checkout-relative; provenance records every source occurrence found by the reproducible scan.",
+	generatedFrom: { requestedRef: ref, repoCommit: resolvedRef, workspaceScanned: existsSync(workspace) },
+	targets: [...records.values()].sort((a, b) => `${a.path}#${a.fragment}`.localeCompare(`${b.path}#${b.fragment}`)),
+};
+writeFileSync(join(root, "docs", "inbound-links.json"), `${JSON.stringify(inventory, null, 2)}\n`);
+console.log(`wrote ${inventory.targets.length} inbound targets from ${tracked.length} repo Markdown files${existsSync(workspace) ? " plus main-workspace" : ""}`);

--- a/scripts/check-doc-claims.mjs
+++ b/scripts/check-doc-claims.mjs
@@ -1,0 +1,91 @@
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const mapPath = join(root, "docs", "claims.json");
+const updating = process.argv.includes("--update");
+const reviewed = process.argv.includes("--reviewed");
+const selectedClaims = new Set(process.argv.filter((arg) => arg.startsWith("--claim=")).map((arg) => arg.slice("--claim=".length)));
+if (updating && (!reviewed || selectedClaims.size === 0)) {
+	console.error("baseline update requires --reviewed and at least one explicit --claim=<id>");
+	process.exit(1);
+}
+const hash = (value) => createHash("sha256").update(value.replaceAll("\r\n", "\n")).digest("hex");
+
+function codeRegion(authority, claim) {
+	const text = readFileSync(join(root, authority.path), "utf8");
+	const start = text.indexOf(authority.start);
+	if (start === -1) throw new Error(`${claim}: missing start marker in ${authority.path}: ${authority.start}`);
+	const end = authority.end ? text.indexOf(authority.end, start + authority.start.length) : text.length;
+	if (end === -1) throw new Error(`${claim}: missing end marker in ${authority.path}: ${authority.end}`);
+	return `${authority.path}\n${text.slice(start, end)}`;
+}
+
+function baseSlug(value) {
+	return value.trim().toLowerCase().replace(/<[^>]*>/g, "").replace(/[`*_~]/g, "")
+		.replace(/[\u0000-\u001f\u007f-\u009f\u2000-\u206f\u2e00-\u2e7f'!"#$%&()+,./:;<=>?@[\\\]^{}|]/g, "").replace(/ /g, "-");
+}
+
+function docSection(doc, claim) {
+	const text = readFileSync(join(root, doc.path), "utf8");
+	const lines = text.split("\n");
+	const seen = new Map();
+	let start = -1;
+	let level = 0;
+	let fenced = false;
+	for (let i = 0; i < lines.length; i++) {
+		if (/^\s*(```|~~~)/.test(lines[i])) {
+			fenced = !fenced;
+			continue;
+		}
+		if (fenced) continue;
+		const heading = /^(#{1,6})\s+(.+?)\s*#*\s*$/.exec(lines[i]);
+		if (!heading) continue;
+		const base = baseSlug(heading[2]);
+		const count = seen.get(base) ?? 0;
+		seen.set(base, count + 1);
+		const slug = count === 0 ? base : `${base}-${count}`;
+		if (start === -1 && slug === doc.fragment) {
+			start = i;
+			level = heading[1].length;
+			continue;
+		}
+		if (start !== -1 && heading[1].length <= level) return `${doc.path}#${doc.fragment}\n${lines.slice(start, i).join("\n")}`;
+	}
+	if (start === -1) throw new Error(`${claim}: missing canonical section ${doc.path}#${doc.fragment}`);
+	return `${doc.path}#${doc.fragment}\n${lines.slice(start).join("\n")}`;
+}
+
+const map = JSON.parse(readFileSync(mapPath, "utf8"));
+const errors = [];
+for (const claim of map.claims) {
+	try {
+		const codeHash = hash(claim.code.map((authority) => codeRegion(authority, claim.id)).join("\n---\n"));
+		const docHash = hash(docSection(claim.doc, claim.id));
+		const codeChanged = claim.baseline?.codeHash !== codeHash;
+		const docChanged = claim.baseline?.docHash !== docHash;
+		if (updating && selectedClaims.has(claim.id)) {
+			if (!codeChanged && !docChanged) errors.push(`${claim.id}: selected for baseline update but neither authority changed`);
+			claim.baseline = { codeHash, docHash };
+		} else {
+			if (codeChanged) errors.push(`${claim.id}: code authority changed; review its canonical docs and explicitly update this claim's joint baseline`);
+			if (docChanged) errors.push(`${claim.id}: canonical doc section changed; review its code authority and explicitly update this claim's joint baseline`);
+		}
+		if (updating) selectedClaims.delete(claim.id);
+	} catch (error) {
+		errors.push(error instanceof Error ? error.message : String(error));
+	}
+}
+if (updating && selectedClaims.size > 0) errors.push(`unknown claim ids: ${[...selectedClaims].join(", ")}`);
+if (updating && errors.length === 0) {
+	writeFileSync(mapPath, `${JSON.stringify(map, null, 2)}\n`);
+	console.log("updated explicitly reviewed joint code/documentation baselines");
+} else if (errors.length > 0) {
+	console.error(errors.join("\n"));
+	process.exit(1);
+} else {
+	console.log(`code-to-doc claims: ${map.claims.length} joint baselines clean`);
+}

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -1,0 +1,193 @@
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { dirname, extname, join, relative, resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+export function githubBaseSlug(value) {
+	return value
+		.trim()
+		.toLowerCase()
+		.replace(/<[^>]*>/g, "")
+		.replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+		.replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+		.replace(/[`*_~]/g, "")
+		// GitHub removes punctuation before replacing each ASCII space with '-'.
+		.replace(/[\u0000-\u001f\u007f-\u009f\u2000-\u206f\u2e00-\u2e7f'!"#$%&()+,./:;<=>?@[\\\]^{}|]/g, "")
+		.replace(/ /g, "-");
+}
+
+export function githubHeadingSlugs(markdown) {
+	const seen = new Map();
+	const slugs = new Set();
+	let fenced = false;
+	for (const line of markdown.split(/\r?\n/)) {
+		if (/^\s*(```|~~~)/.test(line)) {
+			fenced = !fenced;
+			continue;
+		}
+		if (fenced) continue;
+		const match = /^(#{1,6})\s+(.+?)\s*#*\s*$/.exec(line);
+		if (!match) continue;
+		const base = githubBaseSlug(match[2]);
+		const count = seen.get(base) ?? 0;
+		seen.set(base, count + 1);
+		slugs.add(count === 0 ? base : `${base}-${count}`);
+	}
+	return slugs;
+}
+
+function markdownFiles(dir) {
+	const files = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		if ([".git", "node_modules"].includes(entry.name)) continue;
+		const path = join(dir, entry.name);
+		if (entry.isDirectory()) files.push(...markdownFiles(path));
+		else if (entry.isFile() && extname(entry.name).toLowerCase() === ".md") files.push(path);
+	}
+	return files;
+}
+
+function decode(value, context, errors) {
+	try {
+		return decodeURIComponent(value);
+	} catch {
+		errors.push(`${context}: invalid URL encoding in ${value}`);
+		return value;
+	}
+}
+
+function validateTarget(source, rawTarget, errors) {
+	if (!rawTarget || /^(?:https?:|mailto:|tel:|data:)/i.test(rawTarget) || /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(rawTarget)) return;
+	const withoutTitle = rawTarget.replace(/\s+["'][^"']*["']\s*$/, "").replace(/^file:\/\//, "");
+	const hash = withoutTitle.indexOf("#");
+	const rawPath = hash === -1 ? withoutTitle : withoutTitle.slice(0, hash);
+	const rawFragment = hash === -1 ? "" : withoutTitle.slice(hash + 1);
+	const target = rawPath ? resolve(dirname(source), decode(rawPath, relative(root, source), errors)) : source;
+	if (!target.startsWith(`${root}/`) && target !== root) {
+		errors.push(`${relative(root, source)}: local link escapes checkout: ${rawTarget}`);
+		return;
+	}
+	if (!existsSync(target)) {
+		errors.push(`${relative(root, source)}: missing target ${rawTarget}`);
+		return;
+	}
+	if (rawFragment) {
+		if (statSync(target).isDirectory() || extname(target).toLowerCase() !== ".md") {
+			errors.push(`${relative(root, source)}: fragment target is not Markdown: ${rawTarget}`);
+			return;
+		}
+		const fragment = decode(rawFragment, relative(root, source), errors).toLowerCase();
+		if (!githubHeadingSlugs(readFileSync(target, "utf8")).has(fragment)) {
+			errors.push(`${relative(root, source)}: missing fragment #${fragment} in ${relative(root, target)}`);
+		}
+	}
+}
+
+function maskCode(markdown) {
+	let fenced = false;
+	return markdown.split(/(\r?\n)/).map((part) => {
+		if (/^\r?\n$/.test(part)) return part;
+		if (/^\s*(```|~~~)/.test(part)) {
+			fenced = !fenced;
+			return " ".repeat(part.length);
+		}
+		if (fenced) return " ".repeat(part.length);
+		return part.replace(/(`+)(.*?)\1/g, (match) => " ".repeat(match.length));
+	}).join("");
+}
+
+function markdownTargets(rawMarkdown) {
+	const markdown = maskCode(rawMarkdown);
+	const targets = [];
+	const collect = (regex, group = 1) => {
+		for (const match of markdown.matchAll(regex)) if (match[group]) targets.push(match[group]);
+	};
+	// Inline links/images, reference definitions, valid URI/email autolinks, and HTML links.
+	collect(/!?\[[^\]]*\]\(([^)]+)\)/g);
+	for (const match of markdown.matchAll(/^\s*\[[^\]]+\]:\s*(?:<([^>]+)>|(\S+))/gm)) targets.push(match[1] ?? match[2]);
+	collect(/<((?:https?|file|mailto):[^>\s]+)>/gi);
+	collect(/<([A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,})>/gi);
+	collect(/(?:href|src)=["']([^"']+)["']/gi);
+	return targets;
+}
+
+function validateMarkdown(source, errors) {
+	for (const target of markdownTargets(readFileSync(source, "utf8"))) validateTarget(source, target.trim(), errors);
+}
+
+function validateInventory(errors) {
+	const path = join(root, "docs", "inbound-links.json");
+	const inventory = JSON.parse(readFileSync(path, "utf8"));
+	for (const [index, item] of inventory.targets.entries()) {
+		if (typeof item.path !== "string" || typeof item.fragment !== "string" || !Array.isArray(item.provenance) || item.provenance.length === 0) {
+			errors.push(`docs/inbound-links.json: target ${index + 1} requires path, fragment, and provenance`);
+			continue;
+		}
+		if (item.path.startsWith("/") || item.path.includes("..")) {
+			errors.push(`docs/inbound-links.json: target ${index + 1} is not a normalized checkout path: ${item.path}`);
+			continue;
+		}
+		validateTarget(join(root, "INBOUND.md"), `${item.path}${item.fragment ? `#${item.fragment}` : ""}`, errors);
+	}
+}
+
+function selfTest() {
+	const sample = "# Hello, world!\n## A & B\n## Repeat\n## Repeat\n```md\n# Not a heading\n```\n";
+	const actual = githubHeadingSlugs(sample);
+	for (const expected of ["hello-world", "a--b", "repeat", "repeat-1"]) {
+		if (!actual.has(expected)) throw new Error(`GitHub slug self-test missed ${expected}`);
+	}
+	if (actual.has("not-a-heading")) throw new Error("GitHub slug self-test parsed a fenced heading");
+	const extracted = markdownTargets([
+		"[real](target.md)",
+		"`[inline](ignored-inline.md)`",
+		"```md",
+		"[fenced](ignored-fenced.md)",
+		"```",
+		"<https://example.com/docs>",
+		"<docs@example.com>",
+	].join("\n"));
+	for (const expected of ["target.md", "https://example.com/docs", "docs@example.com"]) {
+		if (!extracted.includes(expected)) throw new Error(`link extraction self-test missed ${expected}`);
+	}
+	if (extracted.some((target) => target.includes("ignored-"))) throw new Error("link extraction self-test parsed inline or fenced code");
+
+	const fixture = mkdtempSync(join(root, ".link-check-test-"));
+	try {
+		const source = join(fixture, "source.md");
+		writeFileSync(source, [
+			"[real](target.md)",
+			"`[inline](ignored-inline.md)`",
+			"```md",
+			"[fenced](ignored-fenced.md)",
+			"```",
+			"<https://example.com/docs>",
+			"<docs@example.com>",
+		].join("\n"));
+		writeFileSync(join(fixture, "target.md"), sample);
+		const parsedErrors = [];
+		validateMarkdown(source, parsedErrors);
+		if (parsedErrors.length > 0) throw new Error(`link validation self-test rejected code masking or valid autolinks: ${parsedErrors.join("; ")}`);
+		const failures = [];
+		validateTarget(source, "missing.md", failures);
+		validateTarget(source, "target.md#missing", failures);
+		if (failures.length !== 2) throw new Error("link checker self-test did not reject missing file and fragment");
+		const valid = [];
+		for (const target of ["target.md#hello-world", "target.md#a--b", "target.md#repeat-1"]) validateTarget(source, target, valid);
+		if (valid.length > 0) throw new Error(`link checker self-test rejected GitHub-compatible fragments: ${valid.join("; ")}`);
+	} finally {
+		rmSync(fixture, { recursive: true, force: true });
+	}
+}
+
+selfTest();
+const errors = [];
+for (const file of markdownFiles(root)) validateMarkdown(file, errors);
+validateInventory(errors);
+if (errors.length > 0) {
+	console.error(errors.join("\n"));
+	process.exit(1);
+}
+console.log(`documentation links: ${markdownFiles(root).length} Markdown files and inbound inventory clean`);

--- a/utils.ts
+++ b/utils.ts
@@ -986,12 +986,12 @@ function stripPromptCacheBreakpoints(items: unknown[]): void {
  * Whether an observation can also read what the driver stored depends on
  * routing hydra does not control. Running under the driver's own session id
  * makes it dependable, which is the decision made in index.ts. Measurements
- * are in the OpenAI section of docs/architecture.md.
+ * are in the OpenAI section of docs/providers.md.
  *
- * There is no way to warm up the driver's next turn here the way the Anthropic
- * merge does, because a cache mark is only allowed on input, never on what the
- * model wrote. The observation still reads the final message cheaply either
- * way.
+ * There is no explicit Anthropic-style pre-warm here: a cache mark is legal
+ * only on input, never on what the model wrote. Current Codex accounting still
+ * charges a run-end observation for the newest turn plus its own tail; implicit
+ * caching and shared-session routing determine what later requests can reuse.
  *
  * Any marks pi-ai might add are removed, since on this provider the right
  * number of them is none.


### PR DESCRIPTION
## Summary

- rewrite the README around the simple `capture → specialist handoff → review → deliver` model
- layer the architecture guide from system flow into deeper internals, while moving provider behavior, economics, dates, and evidence to one canonical `docs/providers.md`
- preserve pre-refactor inbound anchors through a SHA-pinned inventory and add GitHub-compatible local link/fragment checks
- bind public claims to joint code-region/document-section baselines so behavior and docs cannot drift silently
- correct the stale Codex run-end accounting comment; no runtime or model-facing prompt behavior changes

The temporary implementation spec was deleted as requested.

## Verification

- `npm run check`
- `npm test` — 166/166
- `git diff --check`
- link-check fixtures cover inline, reference-style, autolink, HTML, bare GitHub, file URL, absolute, and tilde targets; fenced and inline code are ignored
- manually verified code-only and doc-only claim changes both fail, and unreviewed baseline refresh is rejected
