### PR TITLE
Add navigator head

### DIFF
--- a/docs/heads.md
+++ b/docs/heads.md
@@ -39,7 +39,7 @@ A project head with the same name as a user head wins, like project agents and p
 
 Head files are re-read at the start of every agent run and on every `hydra` tool call. Changes apply to observations scheduled after that discovery point without reloading Pi: tune a noisy head before the next run, or follow a write with a `hydra` call when it must take effect during the current run. Duplicate names within one directory warn and keep the first file. If a file behind an active head disappears, the head is dropped from the active set with a notice, never silently.
 
-There are no built-in product heads; the extension has only hidden one-shot diagnostics for delivery smoke tests. The [`heads/`](../heads) directory in this repo holds ready-to-use examples (the quality, security, simplifier, and api-design reviewers, plus the foreman and tuner below); copy what you want:
+There are no built-in product heads; the extension has only hidden one-shot diagnostics for delivery smoke tests. The [`heads/`](../heads) directory in this repo holds ready-to-use examples (the quality, security, simplifier, api-design, and navigator reviewers, plus the foreman and tuner below); copy what you want:
 
 ```bash
 mkdir -p ~/.pi/agent/hydra && cp ~/.pi/agent/git/github.com/pandysp/pi-hydra/heads/*.md ~/.pi/agent/hydra/
@@ -141,7 +141,7 @@ Foreman changes are visible by construction: `manage_heads` accepts a required e
 
 ## Example heads (minimal overlap)
 
-The four review examples are designed to catch different things rather than repeat each other:
+The five review examples are designed to catch different things rather than repeat each other:
 
 ### Quality
 **Lens:** correctness risks, missing verification, dangerous assumptions, obvious regressions, code that looks likely to break.
@@ -163,6 +163,11 @@ The four review examples are designed to catch different things rather than repe
 **Why:** Consumer-facing issues are invisible from inside the code. Inconsistent response shapes, breaking changes, awkward names: the agent is thinking about the implementation rather than the contract.
 **Boundary:** Do not comment on internal code structure.
 
+### Navigator
+**Lens:** done declared without proof, moved goalposts, quietly dropped requirements, guesses where a question was owed, unchecked assumptions, building before understanding, symptom fixes where the user wants the cause.
+**Why:** The other reviewers judge the code; this one judges the trajectory against the ask, like the non-typing partner in pair programming. In human-AI sessions the human plans and the agent executes, and the common failure is the plan quietly coming apart: requirements dropped, wrong problem solved, victory declared on green tests alone.
+**Boundary:** Do not comment on the code itself. Steer at the level of the goal; interrupt only when the whole direction is wrong.
+
 ## More head ideas
 
 Ideas for heads to write yourself, grouped by the shape a head takes. The grouping is loose. Many good heads fit none of these shapes.
@@ -176,7 +181,7 @@ Ideas for heads to write yourself, grouped by the shape a head takes. The groupi
 - **Domain Expert**: business rule accuracy, edge cases in domain logic, terminology. When correctness matters more than code quality.
 - **Architecture**: structural design, coupling, layer separation. For large codebases and early design phases; overlaps with Simplifier on DRY.
 
-**Navigator heads** judge against the task. Their yardstick lives in the session: the spec, the ask, the agreed scope.
+**Navigator heads** judge against the task. Their yardstick lives in the session: the spec, the ask, the agreed scope. A general-purpose navigator ships in [`heads/`](../heads); these are narrower variants:
 
 - **Scope-keeper**: flags work nobody asked for (gold-plating, drive-by refactors, rabbit holes) and steers the run back to the ask.
 - **Spec-alignment**: compares the work against the requirements as stated in the conversation. Catches quiet reinterpretation of the task.
@@ -212,4 +217,4 @@ Heads whose subject is the other heads (the foreman and tuner) are covered in [H
 4. **Bounded:** Clear "do NOT comment on..." prevents overlap.
 5. **Short:** The head instruction is fresh input, so keep it tight. Provider-specific run-end accounting lives in [Provider lifecycle](providers.md#provider-lifecycle).
 
-Overlap notes: Simplifier and Performance both catch redundant operations, so run one or the other; Devil's Advocate and Observability do not overlap with the four review examples.
+Overlap notes: Simplifier and Performance both catch redundant operations, so run one or the other; Devil's Advocate and Observability do not overlap with the five review examples.

--- a/heads/navigator.md
+++ b/heads/navigator.md
@@ -1,0 +1,42 @@
+---
+name: navigator
+description: Judges the run against the ask - done without proof, moved goalposts, dropped requirements, symptom fixes
+tools: []
+---
+Review through a NAVIGATOR lens. You hold the map while the driver holds the
+terrain: judge the run against the ask, not the code. Perfectly good code can
+solve the wrong problem, and no other check catches that.
+
+Flag done without proof. Green tests, a tidy plan, and a confident summary are
+not proof; they are cheap stand-ins that look like evidence.
+
+Flag moved goalposts: weakened tests, hardcoded values, a quietly shrunken
+task. For a stuck agent, shrinking the task is easier than admitting being
+stuck, so failure arrives dressed as success.
+
+Flag dropped requirements and hand them back, house rules included; a skipped
+gate is a dropped requirement. Early instructions fade as the session grows,
+and written rules do not enforce themselves.
+
+Flag guesses where a question was owed. Ambiguity resolves to the cheapest
+reading, not the intended one.
+
+Flag work built on an unchecked assumption ("probably", "should work").
+Everything built on top of it inherits the error.
+
+Flag building before understanding: code appearing while the ask was never
+explored or agreed. Once code exists, every discussion anchors to it and
+clarifying feels like backtracking.
+
+Flag symptom fixes where the user wants the cause. The visible problem is
+cheaper to fix, until the cause resurfaces somewhere more expensive.
+
+Escalate the decisions that belong to the user: the ones they would want to
+have been asked. Absorb and note the rest. Forward everything and the user
+stops reading; decide everything and you make calls that were never yours.
+
+Question first when unsure: a wrong steer derails the run, a wrong question
+costs one answer. One finding per steer. Restate the ask when you steer.
+Escalate only if the last steer changed nothing. Notes for the user go to
+print. Interrupt only when the whole direction is wrong. Do not comment on
+the code itself.


### PR DESCRIPTION
Adds a general-purpose navigator head. It judges the run against the ask instead of the code: done declared without proof, moved goalposts, quietly dropped requirements, guesses where a question was owed, unchecked assumptions, building before understanding, and symptom fixes where the user wants the cause. Each rule carries one sentence on why it exists so the head has the context when it fires. Judge-only, so it cannot touch the work itself.

The list comes from a research pass on what navigators actually do in pair programming plus an analysis of how I steer my own agent sessions. The head is larger than the other examples because of the why sentences.

docs/heads.md: the example list and overlap notes now count the navigator and there is a new Navigator section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)